### PR TITLE
Add Dependabot config, security policy and PyPI release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types: [minor, patch]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Poetry
-        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
-        with:
-          version: "2.4.1"
+        run: pipx install poetry==2.4.1
 
       - name: Assert tag matches project version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/python-stopwatch2
+
+    permissions:
+      contents: read
+      # Required by PyPI Trusted Publishing (OIDC) and PEP 740 attestations.
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
+        with:
+          version: "2.4.1"
+
+      - name: Assert tag matches project version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(poetry version --short)"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::tag '$tag' does not match project version '$pkg'"
+            exit 1
+          fi
+
+      - name: Build distributions
+        run: poetry build
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release of `python-stopwatch2` receives fixes. There are no
+long-term support branches.
+
+| Version | Supported |
+| ------- | --------- |
+| 1.1.x   | Yes       |
+| < 1.1   | No        |
+
+Supported Python versions follow the upstream Python release cycle: versions
+that have reached end-of-life upstream are not supported here either.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for security problems.
+
+Report privately through GitHub Security Advisories:
+[**Report a vulnerability**](https://github.com/devRMA/python-stopwatch2/security/advisories/new).
+
+This is a small, single-maintainer library maintained on a best-effort basis.
+Expect an initial response within 14 days. If a report is confirmed, a fix is
+released as a new version and credited in the advisory unless you prefer
+otherwise.
+
+## Scope
+
+`python-stopwatch2` measures elapsed time and formats it for output. It does no
+network I/O, no filesystem access, no deserialization and no subprocess
+execution, and its only runtime dependency is `colorama`. Realistic issues are
+limited to that dependency and to the output-formatting path.


### PR DESCRIPTION
The repository had none of these. Dependabot alerts were enabled but
security updates were not, so the 16 alerts accumulated for two years
with nothing opening a pull request to fix them.

- `dependabot.yml`: pip and github-actions ecosystems, monthly, with
  dev minor/patch updates grouped into a single pull request. Grouping
  is what keeps this sustainable; ungrouped, a stale lock produces a
  flood that gets ignored. Monthly rather than weekly to match the
  repository's actual pace. Because the actions are pinned by SHA,
  Dependabot updates the SHA and the version comment together.

- `SECURITY.md`: supported versions and private reporting through GitHub
  Security Advisories. Private vulnerability reporting has to be enabled
  in the repository settings for the advisory link to work for
  non-collaborators.

- `release.yml`: publishes on a published GitHub release using PyPI
  Trusted Publishing (OIDC), so no long-lived PyPI API token is needed.
  It asserts the git tag matches the version in pyproject before
  building, because nothing else catches that mismatch. `id-token:
  write` also covers the PEP 740 attestations that the publish action
  generates by default.

Verified `poetry build` produces correct metadata under the new PEP 621
layout: Requires-Python >=3.10, classifiers generated for 3.10-3.14, and
`stopwatch/py.typed` still shipped so PEP 561 typing keeps working.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>