### PR TITLE
Update the docs for 2.0.0, verify every example, and move to VitePress 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,3 +287,9 @@ dist
 
 /docs/.vitepress/dist
 /docs/.vitepress/cache
+
+# Local AI/agent tooling
+.agents/
+.claude/
+.serena/
+skills-lock.json

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -38,9 +38,9 @@ export default defineConfig({
         ["meta", { property: "og:image", content: ogImage }],
         ["meta", { property: "twitter:card", content: "summary_large_image" }],
         ["meta", { property: "twitter:url", content: ogUrl }],
-        ["meta", { property: "twitter:title", content: "ogTitle" }],
+        ["meta", { property: "twitter:title", content: ogTitle }],
         ["meta", { property: "twitter:description", content: ogDescription }],
-        ["meta", { property: "twitter:image", content: "ogImage" }],
+        ["meta", { property: "twitter:image", content: ogImage }],
         // [
         //     "script",
         //     {
@@ -131,12 +131,16 @@ function sidebar() {
                     link: "/guide/getting-started",
                 },
                 {
-                    text: "Profiling a function",
-                    link: "/guide/profiling-function",
-                },
-                {
                     text: "With statement",
                     link: "/guide/with-statement",
+                },
+                {
+                    text: "Measuring laps",
+                    link: "/guide/measuring-laps",
+                },
+                {
+                    text: "Profiling a function",
+                    link: "/guide/profiling-function",
                 },
                 {
                     text: "Other libraries",

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,13 +9,16 @@ import { defineConfig } from "vitepress";
 const ogUrl = "https://stopwatch2.vercel.app/";
 const ogTitle = "Python Stopwatch 2 ⏱";
 const ogSiteTitle = "Python Stopwatch 2";
-const ogDescription = "A simple library to measure code performance.";
+const ogDescription =
+    "A small, fully typed Python stopwatch and profiler. Time a block, time each iteration with laps, or time every call to a function — with mean, median and standard deviation included.";
 const ogImage = "https://stopwatch2.vercel.app/social.png";
 
 export default defineConfig({
     appearance: true,
     title: ogSiteTitle,
+    titleTemplate: `:title | ${ogSiteTitle}`,
     description: ogDescription,
+    lang: "en-US",
 
     head: [
         ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
@@ -36,11 +39,35 @@ export default defineConfig({
         ["meta", { property: "og:title", content: ogTitle }],
         ["meta", { property: "og:description", content: ogDescription }],
         ["meta", { property: "og:image", content: ogImage }],
-        ["meta", { property: "twitter:card", content: "summary_large_image" }],
-        ["meta", { property: "twitter:url", content: ogUrl }],
-        ["meta", { property: "twitter:title", content: ogTitle }],
-        ["meta", { property: "twitter:description", content: ogDescription }],
-        ["meta", { property: "twitter:image", content: ogImage }],
+        ["meta", { property: "og:image:width", content: "1280" }],
+        ["meta", { property: "og:image:height", content: "640" }],
+        ["meta", { property: "og:image:alt", content: ogTitle }],
+        ["meta", { name: "twitter:card", content: "summary_large_image" }],
+        ["meta", { name: "twitter:url", content: ogUrl }],
+        ["meta", { name: "twitter:title", content: ogTitle }],
+        ["meta", { name: "twitter:description", content: ogDescription }],
+        ["meta", { name: "twitter:image", content: ogImage }],
+        ["meta", { name: "twitter:image:alt", content: ogTitle }],
+        [
+            "script",
+            { type: "application/ld+json" },
+            JSON.stringify({
+                "@context": "https://schema.org",
+                "@type": "SoftwareSourceCode",
+                name: ogSiteTitle,
+                description: ogDescription,
+                codeRepository:
+                    "https://github.com/devRMA/python-stopwatch2",
+                programmingLanguage: "Python",
+                url: ogUrl,
+                license: "https://opensource.org/licenses/MIT",
+                author: {
+                    "@type": "Person",
+                    name: "Rafael Alves",
+                    url: "https://github.com/devRMA",
+                },
+            }),
+        ],
         // [
         //     "script",
         //     {

--- a/docs/.vitepress/theme/style/vars.css
+++ b/docs/.vitepress/theme/style/vars.css
@@ -1,7 +1,77 @@
+/*
+ * The brand colour is the logo yellow. It reads well on a dark background but
+ * not on a light one: #ffd859 on white is 1.38:1, where WCAG AA asks for 4.5:1
+ * on body text, which left every link in light mode nearly invisible. Light
+ * mode therefore uses darkened ambers for text and keeps the vivid yellow for
+ * solid fills only.
+ *
+ * `:root` and `.dark` have the same specificity, so every dark override has to
+ * live in the single `.dark` block at the bottom of this file. A later `:root`
+ * rule would win over it.
+ */
+
 :root {
-    --vp-c-brand-1: #ffd859;
+    /* Brand */
+    --vp-c-brand-1: #8a6100; /* 5.54:1 on white */
+    --vp-c-brand-2: #6f4e00; /* 7.59:1 on white, for hover */
+    --vp-c-brand-3: #ffd859; /* solid fills, never text */
+    --vp-c-brand-soft: rgba(255, 216, 89, 0.24);
+
+    --vp-font-family-mono: 'IBM Plex Mono', 'Menlo', 'Monaco', 'Consolas',
+        'Courier New', monospace;
+
+    /*
+     * Brand buttons are filled with the yellow in both modes, so their label
+     * has to be dark. The default is white, which is 1.38:1 against it.
+     */
+    --vp-button-brand-border: transparent;
+    --vp-button-brand-text: #1b1b1f; /* 12.44:1 on #ffd859 */
+    --vp-button-brand-bg: #ffd859;
+    --vp-button-brand-hover-border: transparent;
+    --vp-button-brand-hover-text: #1b1b1f;
+    --vp-button-brand-hover-bg: #ffe07a;
+    --vp-button-brand-active-border: transparent;
+    --vp-button-brand-active-text: #1b1b1f;
+    --vp-button-brand-active-bg: #f0c53f;
+
+    /*
+     * The hero name is drawn with background-clip:text. A yellow gradient over
+     * a white page is 1.74:1 at best, below even the 3:1 that large text is
+     * allowed, so light mode gets a solid amber and the gradient is dark-only.
+     */
+    --vp-home-hero-name-color: #8a6100;
+    --vp-home-hero-name-background: transparent;
+
+    --vp-home-hero-image-background-image: linear-gradient(
+        -45deg,
+        rgba(255, 183, 39, 0.6) 30%,
+        rgba(255, 216, 89, 0.6)
+    );
+    --vp-home-hero-image-filter: blur(44px);
+}
+
+@media (min-width: 640px) {
+    :root {
+        --vp-home-hero-image-filter: blur(56px);
+    }
+}
+
+@media (min-width: 960px) {
+    :root {
+        --vp-home-hero-image-filter: blur(68px);
+    }
+}
+
+.dark {
+    --vp-c-brand-1: #ffd859; /* 12.44:1 on the dark background */
     --vp-c-brand-2: #ffb727;
     --vp-c-brand-3: #d8a72a;
+    --vp-c-brand-soft: rgba(255, 216, 89, 0.16);
 
-    --vp-font-family-mono: 'IBM Plex Mono', 'Menlo', 'Monaco', 'Consolas', 'Courier New', monospace;
+    --vp-home-hero-name-color: transparent;
+    --vp-home-hero-name-background: linear-gradient(
+        120deg,
+        #ffb727 30%,
+        #ffd859
+    );
 }

--- a/docs/api/decorators.md
+++ b/docs/api/decorators.md
@@ -1,10 +1,17 @@
+---
+title: profile decorator
+description: API reference for the profile decorator — measure every call to a function, including async def, with periodic statistics reports.
+---
+
 # Decorators
 
-**Source code: [stopwatch/profile.py](https://github.com/devRMA/python-stopwatch2/blob/main/stopwatch/profile.py)**
+**Source:** [stopwatch/profile.py](https://github.com/devRMA/python-stopwatch2/blob/main/stopwatch/profile.py)
 
 ## profile
 
-This decorator is used to profiling the execution time of a function.
+Measures every call to a function and prints the statistics as they build up.
+Reach for it when you want to know what a function costs across a whole run,
+rather than timing one specific block.
 
 ```python
 def profile(
@@ -14,119 +21,122 @@ def profile(
 ) -> Callable[[Callable[..., RT]], Callable[..., RT]]:
 ```
 
-**Parameters**
-
-Both are keyword-only, so a misspelled name is an error instead of being
-silently ignored.
-
-- `name`: The name used for the statistics.
-  - Type: [str](https://docs.python.org/3/library/stdtypes.html#str) | None
-  - Default: Name of decorated function
-- `report_every`: Report once every this many calls. If None is passed, the report will only be printed at the end of the execution.
-  - Type: [int](https://docs.python.org/3/library/functions.html#int) | None
-  - Default: 1
-
-**Raises**
-
-- [ValueError](https://docs.python.org/3/library/exceptions.html#ValueError): if `report_every` is smaller than 1.
-
-::: info
-The decorator must be called, so write `@profile()` and not `@profile`.
-:::
-
-::: warning
-A generator function is measured only for the time it takes to build the
-generator, not to consume it, because timing the consumption would change what
-the function does. Wrap the loop that consumes it in a
-[lap](/api/stopwatch#lap) instead.
-:::
-
-::: details Example
-
 ```python
 from time import sleep
 from stopwatch import profile
 
-@profile(name='My function')
-def wait_for(time: float) -> None:
-    sleep(time)
 
-for time in [0.1, 0.2, 0.3, 0.4, 0.5]:
-    wait_for(time)
-print('end')
+@profile()
+def parse(n: int) -> None:
+    sleep(n / 100)
 
-# [__main__#My function] hits=1, mean=100.14ms, min=100.14ms, median=100.14ms, max=100.14ms, dev=0.00μs
-# [__main__#My function] hits=2, mean=150.20ms, min=100.14ms, median=150.20ms, max=200.26ms, dev=50.06ms
-# [__main__#My function] hits=3, mean=200.25ms, min=100.14ms, median=200.26ms, max=300.35ms, dev=81.74ms
-# [__main__#My function] hits=4, mean=250.30ms, min=100.14ms, median=250.30ms, max=400.44ms, dev=111.92ms
-# [__main__#My function] hits=5, mean=300.35ms, min=100.14ms, median=300.35ms, max=500.55ms, dev=141.56ms
-# end
+
+for n in (8, 12, 10):
+    parse(n)
+
+# [__main__#parse] hits=1, mean=80.13ms, min=80.13ms, median=80.13ms, max=80.13ms, dev=0.00μs
+# [__main__#parse] hits=2, mean=100.19ms, min=80.13ms, median=100.19ms, max=120.24ms, dev=20.06ms
+# [__main__#parse] hits=3, mean=100.16ms, min=80.13ms, median=100.11ms, max=120.24ms, dev=16.38ms
 ```
 
-::: info
-With the default `report_every=1` every call is reported, so nothing is left to
-print when the process exits. The exit report only fires when the last calls
-were not covered by an inline report, as in the `report_every=2` example below.
+The prefix is `[module#name]`, and `hits` is the number of calls so far.
+
+### Parameters
+
+Both are keyword-only, so a misspelled name fails loudly instead of being
+quietly ignored.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str \| None` | `None` | Label for the report. Defaults to the function's own name. |
+| `report_every` | `int \| None` | `1` | Print a report every N calls. `None` prints only once, when the process exits. |
+
+**Raises** [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError)
+if `report_every` is below 1:
+
+```python
+profile(report_every=0)
+# ValueError: report_every must be >= 1 or None, got 0
+```
+
+::: warning It has to be called
+Write `@profile()`, not `@profile`. Without the parentheses you get
+`TypeError: profile() takes 0 positional arguments but 1 was given`.
 :::
 
-<br>
+### Reporting less often
+
+Reporting on every call gets noisy for a function called thousands of times.
 
 ```python
 from time import sleep
 from stopwatch import profile
+
 
 @profile(report_every=2)
-def report_every2(time: float) -> None:
-    sleep(time)
+def every_two(t: float) -> None:
+    sleep(t)
+
 
 @profile(report_every=None)
-def no_report(time: float) -> None:
-    sleep(time)
+def only_at_exit(t: float) -> None:
+    sleep(t)
 
-for time in [0.1, 0.2, 0.3, 0.4, 0.5]:
-    report_every2(time)
-    no_report(time)
+
+for t in [0.1, 0.2, 0.3, 0.4, 0.5]:
+    every_two(t)
+    only_at_exit(t)
 print('end')
 
-# [__main__#report_every2] hits=2, mean=150.20ms, min=100.15ms, median=150.20ms, max=200.25ms, dev=50.05ms
-# [__main__#report_every2] hits=4, mean=250.30ms, min=100.15ms, median=250.30ms, max=400.46ms, dev=111.92ms
+# [__main__#every_two] hits=2, mean=150.12ms, min=100.14ms, median=150.12ms, max=200.10ms, dev=49.98ms
+# [__main__#every_two] hits=4, mean=250.12ms, min=100.14ms, median=250.11ms, max=400.10ms, dev=111.80ms
 # end
-# [__main__#no_report] hits=5, mean=300.36ms, min=100.15ms, median=300.36ms, max=500.58ms, dev=141.57ms
-# [__main__#report_every2] hits=5, mean=300.43ms, min=100.15ms, median=300.36ms, max=500.94ms, dev=141.68ms
+# [__main__#only_at_exit] hits=5, mean=300.10ms, min=100.12ms, median=300.08ms, max=500.10ms, dev=141.41ms
+# [__main__#every_two] hits=5, mean=300.12ms, min=100.14ms, median=300.13ms, max=500.13ms, dev=141.42ms
 ```
 
-<br>
+The last two lines are printed as the process exits. `every_two` gets one
+because its fifth call was not covered by a periodic report; with the default
+`report_every=1`, every call is already reported and nothing is left to print at
+exit.
 
-`async def` functions are measured across the `await`, not just the creation of
-the coroutine:
+### async def
+
+Coroutine functions are measured across the `await`, not just the moment the
+coroutine is created.
 
 ```python
 import asyncio
 from stopwatch import profile
+
 
 @profile(name='fetch')
 async def fetch() -> str:
     await asyncio.sleep(0.2)
     return 'ok'
 
+
 asyncio.run(fetch())
 
 # [__main__#fetch] hits=1, mean=200.47ms, min=200.47ms, median=200.47ms, max=200.47ms, dev=0.00μs
 ```
 
-<br>
+### Calls that raise
 
-A call that raises is still recorded, so a function that fails does not
-disappear from the report:
+Still recorded, so a function that starts failing does not quietly disappear
+from the report — which matters, because those are usually the calls worth
+looking at.
 
 ```python
 from time import sleep
 from stopwatch import profile
 
+
 @profile(name='flaky')
 def flaky() -> None:
     sleep(0.1)
     raise RuntimeError('nope')
+
 
 for _ in range(2):
     try:
@@ -138,4 +148,32 @@ for _ in range(2):
 # [__main__#flaky] hits=2, mean=100.12ms, min=100.11ms, median=100.12ms, max=100.13ms, dev=8.48μs
 ```
 
+### Limitations
+
+::: warning Generator functions
+A generator function is measured only for the time it takes to *build* the
+generator, which is almost nothing — not for consuming it. Timing the
+consumption would change what the function does. Wrap the loop that consumes it
+in a [`lap()`](/api/stopwatch#lap) instead:
+
+```python
+sw = Stopwatch(autostart=False)
+with sw.lap():
+    for row in rows():
+        handle(row)
+```
 :::
+
+::: info Memory
+Every recorded duration is kept, because the median needs all of them, and the
+exit report holds them until the process ends — roughly 3 MB per 100 000 calls
+per decorated function. Fine for a script or a test run; for a hot path in a
+long-lived process, prefer a [`lap()`](/api/stopwatch#lap) you control.
+:::
+
+## See also
+
+- [Profiling a function](/guide/profiling-function) — the guide.
+- [`Stopwatch.lap()`](/api/stopwatch#lap) — measuring a block instead of a whole
+  function.
+- [`Statistics`](/api/statistics) — the numbers behind the report.

--- a/docs/api/decorators.md
+++ b/docs/api/decorators.md
@@ -6,14 +6,40 @@
 
 This decorator is used to profiling the execution time of a function.
 
+```python
+def profile(
+    *,
+    name: str | None = None,
+    report_every: int | None = 1,
+) -> Callable[[Callable[..., RT]], Callable[..., RT]]:
+```
+
 **Parameters**
 
+Both are keyword-only, so a misspelled name is an error instead of being
+silently ignored.
+
 - `name`: The name used for the statistics.
-  - Type: [str](https://docs.python.org/3/library/stdtypes.html#str)
+  - Type: [str](https://docs.python.org/3/library/stdtypes.html#str) | None
   - Default: Name of decorated function
-- report_every: The number of times to report the statistics. If None is passed, the report will only be printed at the end of the execution.
-  - Type: Optional[[int](https://docs.python.org/3/library/functions.html#int)]
+- `report_every`: Report once every this many calls. If None is passed, the report will only be printed at the end of the execution.
+  - Type: [int](https://docs.python.org/3/library/functions.html#int) | None
   - Default: 1
+
+**Raises**
+
+- [ValueError](https://docs.python.org/3/library/exceptions.html#ValueError): if `report_every` is smaller than 1.
+
+::: info
+The decorator must be called, so write `@profile()` and not `@profile`.
+:::
+
+::: warning
+A generator function is measured only for the time it takes to build the
+generator, not to consume it, because timing the consumption would change what
+the function does. Wrap the loop that consumes it in a
+[lap](/api/stopwatch#lap) instead.
+:::
 
 ::: details Example
 
@@ -35,8 +61,13 @@ print('end')
 # [__main__#My function] hits=4, mean=250.30ms, min=100.14ms, median=250.30ms, max=400.44ms, dev=111.92ms
 # [__main__#My function] hits=5, mean=300.35ms, min=100.14ms, median=300.35ms, max=500.55ms, dev=141.56ms
 # end
-# [__main__#My function] hits=5, mean=300.35ms, min=100.14ms, median=300.35ms, max=500.55ms, dev=141.56ms
 ```
+
+::: info
+With the default `report_every=1` every call is reported, so nothing is left to
+print when the process exits. The exit report only fires when the last calls
+were not covered by an inline report, as in the `report_every=2` example below.
+:::
 
 <br>
 
@@ -62,6 +93,49 @@ print('end')
 # end
 # [__main__#no_report] hits=5, mean=300.36ms, min=100.15ms, median=300.36ms, max=500.58ms, dev=141.57ms
 # [__main__#report_every2] hits=5, mean=300.43ms, min=100.15ms, median=300.36ms, max=500.94ms, dev=141.68ms
+```
+
+<br>
+
+`async def` functions are measured across the `await`, not just the creation of
+the coroutine:
+
+```python
+import asyncio
+from stopwatch import profile
+
+@profile(name='fetch')
+async def fetch() -> str:
+    await asyncio.sleep(0.2)
+    return 'ok'
+
+asyncio.run(fetch())
+
+# [__main__#fetch] hits=1, mean=200.47ms, min=200.47ms, median=200.47ms, max=200.47ms, dev=0.00μs
+```
+
+<br>
+
+A call that raises is still recorded, so a function that fails does not
+disappear from the report:
+
+```python
+from time import sleep
+from stopwatch import profile
+
+@profile(name='flaky')
+def flaky() -> None:
+    sleep(0.1)
+    raise RuntimeError('nope')
+
+for _ in range(2):
+    try:
+        flaky()
+    except RuntimeError:
+        pass
+
+# [__main__#flaky] hits=1, mean=100.13ms, min=100.13ms, median=100.13ms, max=100.13ms, dev=0.00μs
+# [__main__#flaky] hits=2, mean=100.12ms, min=100.11ms, median=100.12ms, max=100.13ms, dev=8.48μs
 ```
 
 :::

--- a/docs/api/lap.md
+++ b/docs/api/lap.md
@@ -2,6 +2,17 @@
 
 **Source code: [stopwatch/lap.py](https://github.com/devRMA/python-stopwatch2/blob/main/stopwatch/lap.py)**
 
+A single measured interval. You do not create these yourself: a
+[Stopwatch](/api/stopwatch) creates one when it starts and one for each
+[lap](/api/stopwatch#lap) block, and exposes them through
+[laps](/api/stopwatch#laps).
+
+## Supported operations
+
+```python
+repr(lap)  # <Lap running=False elapsed=1.0000>
+```
+
 ## Attributes
 
 All attributes of the `Lap` class.
@@ -16,7 +27,8 @@ If the lap is running.
 
 ### elapsed
 
-The elapsed time in seconds.
+The elapsed time in seconds. While the lap is running this is measured against
+the current clock, so it grows between reads until the lap is stopped.
 
 **Type**
 
@@ -44,7 +56,8 @@ It is not recommended to use this method. Instead, use the stopwatch [start](/ap
 def stop(self) -> None:
 ```
 
-Stops the lap, freezing the duration.
+Stops the lap, freezing the duration. Calling it on a lap that is already
+stopped does nothing.
 
 ::: danger
 It is not recommended to use this method. Instead, use the Stopwatch [stop](/api/stopwatch#stop) method.

--- a/docs/api/lap.md
+++ b/docs/api/lap.md
@@ -1,42 +1,64 @@
+---
+title: Lap
+description: API reference for the Lap class — a single measured interval inside a Stopwatch.
+---
+
 # Lap
 
-**Source code: [stopwatch/lap.py](https://github.com/devRMA/python-stopwatch2/blob/main/stopwatch/lap.py)**
+A single measured interval. You do not create these: a
+[`Stopwatch`](/api/stopwatch) opens one when it starts and one for each
+[`lap()`](/api/stopwatch#lap) block, and hands them to you through
+[`laps`](/api/stopwatch#laps).
 
-A single measured interval. You do not create these yourself: a
-[Stopwatch](/api/stopwatch) creates one when it starts and one for each
-[lap](/api/stopwatch#lap) block, and exposes them through
-[laps](/api/stopwatch#laps).
+**Source:** [stopwatch/lap.py](https://github.com/devRMA/python-stopwatch2/blob/main/stopwatch/lap.py)
+
+```python
+sw = Stopwatch(autostart=False)
+with sw.lap():
+    sleep(1)
+
+lap = sw.laps[0]
+print(lap.elapsed)  # 1.0001530810004624
+print(lap.running)  # False
+print(repr(lap))    # <Lap running=False elapsed=1.0002>
+```
+
+A `Lap` can itself be stopped and started again, accumulating each stretch into
+its `elapsed`. `Stopwatch` never does that, though — every
+[`start()`](/api/stopwatch#start) opens a new lap, so
+[`stop()`](/api/stopwatch#stop) followed by `start()` gives you two entries in
+[`laps`](/api/stopwatch#laps) rather than one resumed lap.
 
 ## Supported operations
 
 ```python
-repr(lap)  # <Lap running=False elapsed=1.0000>
+repr(lap)  # <Lap running=False elapsed=1.0001>
 ```
 
 ## Attributes
 
-All attributes of the `Lap` class.
-
 ### running
 
-If the lap is running.
+Whether the lap is currently counting.
 
-**Type**
-
-- [bool](https://docs.python.org/3/library/functions.html#bool)
+**Type:** [`bool`](https://docs.python.org/3/library/functions.html#bool)
 
 ### elapsed
 
-The elapsed time in seconds. While the lap is running this is measured against
-the current clock, so it grows between reads until the lap is stopped.
+The measured time in seconds. While the lap is running this is computed against
+the current clock, so it grows between reads; once stopped it is frozen.
 
-**Type**
-
-- [float](https://docs.python.org/3/library/functions.html#float)
+**Type:** [`float`](https://docs.python.org/3/library/functions.html#float)
 
 ## Methods
 
-All methods of the `Lap` class.
+::: danger Use the Stopwatch instead
+These exist because `Stopwatch` needs them. Driving a `Lap` by hand bypasses the
+stopwatch's bookkeeping, so its [`laps`](/api/stopwatch#laps) and
+[`elapsed`](/api/stopwatch#elapsed) stop agreeing with reality. Use
+[`Stopwatch.lap()`](/api/stopwatch#lap), [`start()`](/api/stopwatch#start) and
+[`stop()`](/api/stopwatch#stop).
+:::
 
 ### start
 
@@ -44,11 +66,7 @@ All methods of the `Lap` class.
 def start(self) -> None:
 ```
 
-Starts the lap if not running.
-
-::: danger
-It is not recommended to use this method. Instead, use the stopwatch [start](/api/stopwatch#start) method.
-:::
+Starts counting.
 
 ### stop
 
@@ -56,9 +74,10 @@ It is not recommended to use this method. Instead, use the stopwatch [start](/ap
 def stop(self) -> None:
 ```
 
-Stops the lap, freezing the duration. Calling it on a lap that is already
+Stops counting and freezes the duration. Calling it on a lap that is already
 stopped does nothing.
 
-::: danger
-It is not recommended to use this method. Instead, use the Stopwatch [stop](/api/stopwatch#stop) method.
-:::
+## See also
+
+- [`Stopwatch.laps`](/api/stopwatch#laps) — the list these live in.
+- [Measuring laps](/guide/measuring-laps) — the guide.

--- a/docs/api/statistics.md
+++ b/docs/api/statistics.md
@@ -1,12 +1,48 @@
+---
+title: Statistics
+description: API reference for the Statistics class — mean, median, min, max, total, variance and standard deviation over a set of measurements.
+---
+
 # Statistics
 
-**Source code: [stopwatch/statistics.py](https://github.com/devRMA/python-stopwatch2/blob/main/stopwatch/statistics.py)**
+Summarises a set of durations. You usually get one from
+[`Stopwatch.statistics`](/api/stopwatch#statistics) rather than building it
+yourself, but it works standalone on any list of numbers.
+
+**Source:** [stopwatch/statistics.py](https://github.com/devRMA/python-stopwatch2/blob/main/stopwatch/statistics.py)
+
+```python
+from stopwatch import Statistics
+```
+
+## At a glance
+
+| What | Members |
+|---|---|
+| **Create** | [`Statistics(values)`](#initialization) · [`add(value)`](#add) |
+| **Read** | [`mean`](#mean) · [`median`](#median) · [`minimum`](#minimum) · [`maximum`](#maximum) · [`total`](#total) · [`variance`](#variance) · [`stdev`](#stdev) |
+| **Export** | [`to_dict()`](#to-dict) · [`len(stats)`](#supported-operations) |
+
+```python
+from stopwatch import Statistics
+
+stats = Statistics([0.1, 0.2, 0.3, 0.4, 0.5])
+
+print(len(stats))       # 5
+print(stats.mean)       # 0.3
+print(stats.minimum)    # 0.1
+print(stats.median)     # 0.3
+print(stats.maximum)    # 0.5
+print(stats.total)      # 1.5
+print(stats.variance)   # 0.02
+print(stats.stdev)      # 0.1414213562373095
+```
 
 ## Supported operations
 
 ```python
-len(x)   # the number of values
-repr(x)  # <Statistics values=[0.1, 0.2, 0.3]>
+len(stats)   # 5
+repr(stats)  # <Statistics values=[0.1, 0.2, 0.3, 0.4, 0.5]>
 ```
 
 ## Initialization
@@ -15,196 +51,118 @@ repr(x)  # <Statistics values=[0.1, 0.2, 0.3]>
 def __init__(self, values: list[float] | None = None) -> None:
 ```
 
-- `values`: The list of values to be used for the statistics.
-  - Type: [list](https://docs.python.org/3/library/stdtypes.html#list)[[float](https://docs.python.org/3/library/functions.html#float)] | None
-  - Default: None
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `values` | `list[float] \| None` | `None` | Initial values, in seconds. Copied, so later changes to your list do not affect the statistics. |
 
-::: info
-The list is copied, so later changes to the list you pass in do not affect the
-statistics. Use [add](#add) to append more values.
+```python
+values = [1.0, 2.0]
+stats = Statistics(values)
+
+stats.add(3.0)
+print(values)       # [1.0, 2.0]  -- untouched
+print(len(stats))   # 3
+```
+
+::: danger Empty statistics raise
+With no values, `mean`, `median`, `variance` and `stdev` raise
+[`StatisticsError`](https://docs.python.org/3/library/statistics.html#statistics.StatisticsError),
+and `maximum` and `minimum` raise `ValueError`. Only `total` is defined, as
+`0.0`. Guard with `len()` when the set may be empty:
+
+```python
+if len(stats):
+    print(stats.mean)
+```
 :::
 
 ## Attributes
 
-All attributes of the `Statistics` class.
-
-::: warning
-`mean`, `median`, `variance` and `stdev` raise
-[StatisticsError](https://docs.python.org/3/library/statistics.html#statistics.StatisticsError)
-when there are no values, and `maximum` and `minimum` raise `ValueError`. Only
-`total` is defined for an empty `Statistics`, where it is `0.0`. Check `len()`
-first if the values may be empty.
-:::
+Every value is in seconds. Pass them through
+[`format_elapsed_time`](/api/utils#format-elapsed-time) for readable units.
 
 ### mean
 
-The mean value in seconds.
+The arithmetic mean.
 
-**Type**
-
-- [float](https://docs.python.org/3/library/functions.html#float)
-
-::: details Example
+**Type:** [`float`](https://docs.python.org/3/library/functions.html#float)
 
 ```python
-from stopwatch import Stopwatch
-from random import randint
-from time import sleep
-
-with Stopwatch() as sw:
-    for _ in range(1, 6):
-        with sw.lap():
-            sleep(randint(1, 10) / 10)
-print(sw.statistics.mean)  # 0.5
+print(Statistics([0.1, 0.2, 0.3, 0.4, 0.5]).mean)  # 0.3
 ```
-
-:::
 
 ### maximum
 
-The maximum value in seconds.
+The largest value — the slowest lap or call, which is usually the interesting
+one.
 
-**Type**
-
-- [float](https://docs.python.org/3/library/functions.html#float)
-
-::: details Example
+**Type:** [`float`](https://docs.python.org/3/library/functions.html#float)
 
 ```python
-from stopwatch import Stopwatch
-from random import randint
-from time import sleep
-
-with Stopwatch() as sw:
-    for _ in range(1, 6):
-        with sw.lap():
-            sleep(randint(1, 10) / 10)
-print(sw.statistics.maximum)  # 0.9
+print(Statistics([0.1, 0.2, 0.3, 0.4, 0.5]).maximum)  # 0.5
 ```
-
-:::
 
 ### median
 
-The median value in seconds.
+The middle value. Less sensitive to one outlier than [`mean`](#mean), so
+comparing the two tells you whether a single slow run is dragging the average.
 
-**Type**
-
-- [float](https://docs.python.org/3/library/functions.html#float)
-
-::: details Example
+**Type:** [`float`](https://docs.python.org/3/library/functions.html#float)
 
 ```python
-from stopwatch import Stopwatch
-from random import randint
-from time import sleep
-
-with Stopwatch() as sw:
-    for _ in range(1, 6):
-        with sw.lap():
-            sleep(randint(1, 10) / 10)
-print(sw.statistics.median)  # 0.5
+print(Statistics([0.1, 0.2, 0.3, 0.4, 0.5]).median)  # 0.3
+print(Statistics([0.1, 0.1, 0.1, 0.1, 9.9]).median)  # 0.1
+print(Statistics([0.1, 0.1, 0.1, 0.1, 9.9]).mean)    # 2.06
 ```
-
-:::
 
 ### minimum
 
-The minimum value in seconds.
+The smallest value — the best case, closest to the cost without interference.
 
-**Type**
-
-- [float](https://docs.python.org/3/library/functions.html#float)
-
-::: details Example
+**Type:** [`float`](https://docs.python.org/3/library/functions.html#float)
 
 ```python
-from stopwatch import Stopwatch
-from random import randint
-from time import sleep
-
-with Stopwatch() as sw:
-    for _ in range(1, 6):
-        with sw.lap():
-            sleep(randint(1, 10) / 10)
-print(sw.statistics.minimum)  # 0.1
+print(Statistics([0.1, 0.2, 0.3, 0.4, 0.5]).minimum)  # 0.1
 ```
-
-:::
 
 ### total
 
-The total value in seconds.
+The sum. This is the only attribute defined for an empty `Statistics`, where it
+is `0.0`.
 
-**Type**
-
-- [float](https://docs.python.org/3/library/functions.html#float)
-
-::: details Example
+**Type:** [`float`](https://docs.python.org/3/library/functions.html#float)
 
 ```python
-from stopwatch import Stopwatch
-from random import randint
-from time import sleep
-
-with Stopwatch() as sw:
-    for _ in range(1, 6):
-        with sw.lap():
-            sleep(randint(1, 10) / 10)
-print(sw.statistics.total)  # 2.5
+print(Statistics([0.1, 0.2, 0.3, 0.4, 0.5]).total)  # 1.5
+print(Statistics().total)                            # 0.0
 ```
-
-:::
 
 ### variance
 
-The variance value in seconds.
+The population variance. See [`stdev`](#stdev) for the same spread in seconds
+rather than seconds squared.
 
-**Type**
-
-- [float](https://docs.python.org/3/library/functions.html#float)
-
-::: details Example
+**Type:** [`float`](https://docs.python.org/3/library/functions.html#float)
 
 ```python
-from stopwatch import Stopwatch
-from random import randint
-from time import sleep
-
-with Stopwatch() as sw:
-    for _ in range(1, 6):
-        with sw.lap():
-            sleep(randint(1, 10) / 10)
-print(sw.statistics.variance)  # 0.09
+print(Statistics([0.1, 0.2, 0.3, 0.4, 0.5]).variance)  # 0.02
 ```
-
-:::
 
 ### stdev
 
-The population standard deviation in seconds, that is, the square root of
-[variance](#variance). This is the `dev` field of the
-[report](/api/stopwatch#report).
+The population standard deviation, the square root of [`variance`](#variance).
+This is the `dev` field of the [reports](/api/stopwatch#report): a small value
+means the measurements agree, a large one means they scatter and the mean is not
+telling you much.
 
-**Type**
-
-- [float](https://docs.python.org/3/library/functions.html#float)
-
-::: details Example
+**Type:** [`float`](https://docs.python.org/3/library/functions.html#float)
 
 ```python
-from stopwatch import Statistics
-
-stats = Statistics([0.1, 0.2, 0.3, 0.4, 0.5])
-print(stats.variance)  # 0.02
-print(stats.stdev)     # 0.1414213562373095
+print(Statistics([0.1, 0.2, 0.3, 0.4, 0.5]).stdev)  # 0.1414213562373095
+print(Statistics([0.3, 0.3, 0.3, 0.3, 0.3]).stdev)  # 0.0
 ```
 
-:::
-
 ## Methods
-
-All methods of the `Statistics` class.
 
 ### add
 
@@ -212,12 +170,20 @@ All methods of the `Statistics` class.
 def add(self, value: float) -> None:
 ```
 
-Add a value to the list of values.
+Appends a value, in seconds.
 
-**Parameters**
+| Parameter | Type | Description |
+|---|---|---|
+| `value` | [`float`](https://docs.python.org/3/library/functions.html#float) | The duration to record. |
 
-- `value`: The value to be added.
-  - Type: [float](https://docs.python.org/3/library/functions.html#float)
+```python
+stats = Statistics()
+stats.add(0.1)
+stats.add(0.3)
+
+print(len(stats))  # 2
+print(stats.mean)  # 0.2
+```
 
 ### to_dict
 
@@ -225,34 +191,22 @@ Add a value to the list of values.
 def to_dict(self) -> dict[str, float]:
 ```
 
-Get a dictionary with all statistics.
+Every statistic as a plain dictionary, handy for logging or JSON.
 
-::: info
-[stdev](#stdev) is not included, to keep the keys stable for anything already
-consuming this dictionary. Read it from the attribute when you need it.
-:::
-
-**Returns**
-
-- The dictionary with all statistics.
-
-**Return type**
-
-- [dict](https://docs.python.org/3/library/stdtypes.html#dict)[[str](https://docs.python.org/3/library/stdtypes.html#str), [float](https://docs.python.org/3/library/functions.html#float)]
-
-::: details Example
+**Returns** `dict[str, float]`
 
 ```python
-from stopwatch import Stopwatch
-from random import randint
-from time import sleep
-
-with Stopwatch() as sw:
-    for _ in range(1, 6):
-        with sw.lap():
-            sleep(randint(1, 10) / 10)
-print(sw.statistics.to_dict())
-# {'mean': 0.5, 'maximum': 0.9, 'median': 0.5, 'minimum': 0.1, 'total': 2.5, 'variance': 0.09}
+print(Statistics([0.1, 0.2, 0.3, 0.4, 0.5]).to_dict())
+# {'mean': 0.3, 'maximum': 0.5, 'median': 0.3, 'minimum': 0.1, 'total': 1.5, 'variance': 0.02}
 ```
 
+::: info
+[`stdev`](#stdev) is deliberately not in the dictionary, so the keys stay stable
+for anything already consuming it. Read it from the attribute.
 :::
+
+## See also
+
+- [`Stopwatch.statistics`](/api/stopwatch#statistics) — where these usually come
+  from.
+- [Measuring laps](/guide/measuring-laps) — building up a set of measurements.

--- a/docs/api/statistics.md
+++ b/docs/api/statistics.md
@@ -2,25 +2,39 @@
 
 **Source code: [stopwatch/statistics.py](https://github.com/devRMA/python-stopwatch2/blob/main/stopwatch/statistics.py)**
 
-Supported Operations
+## Supported operations
 
 ```python
-len(x)  # get the length of the values
+len(x)   # the number of values
+repr(x)  # <Statistics values=[0.1, 0.2, 0.3]>
 ```
 
 ## Initialization
 
 ```python
-def __init__(self, values: Optional[List[float]] = None) -> None:
+def __init__(self, values: list[float] | None = None) -> None:
 ```
 
 - `values`: The list of values to be used for the statistics.
-  - Type: Optional[List[[float](https://docs.python.org/3/library/functions.html#float)]]
+  - Type: [list](https://docs.python.org/3/library/stdtypes.html#list)[[float](https://docs.python.org/3/library/functions.html#float)] | None
   - Default: None
+
+::: info
+The list is copied, so later changes to the list you pass in do not affect the
+statistics. Use [add](#add) to append more values.
+:::
 
 ## Attributes
 
 All attributes of the `Statistics` class.
+
+::: warning
+`mean`, `median`, `variance` and `stdev` raise
+[StatisticsError](https://docs.python.org/3/library/statistics.html#statistics.StatisticsError)
+when there are no values, and `maximum` and `minimum` raise `ValueError`. Only
+`total` is defined for an empty `Statistics`, where it is `0.0`. Check `len()`
+first if the values may be empty.
+:::
 
 ### mean
 
@@ -166,6 +180,28 @@ print(sw.statistics.variance)  # 0.09
 
 :::
 
+### stdev
+
+The population standard deviation in seconds, that is, the square root of
+[variance](#variance). This is the `dev` field of the
+[report](/api/stopwatch#report).
+
+**Type**
+
+- [float](https://docs.python.org/3/library/functions.html#float)
+
+::: details Example
+
+```python
+from stopwatch import Statistics
+
+stats = Statistics([0.1, 0.2, 0.3, 0.4, 0.5])
+print(stats.variance)  # 0.02
+print(stats.stdev)     # 0.1414213562373095
+```
+
+:::
+
 ## Methods
 
 All methods of the `Statistics` class.
@@ -186,10 +222,15 @@ Add a value to the list of values.
 ### to_dict
 
 ```python
-def to_dict(self) -> Dict[str, float]:
+def to_dict(self) -> dict[str, float]:
 ```
 
 Get a dictionary with all statistics.
+
+::: info
+[stdev](#stdev) is not included, to keep the keys stable for anything already
+consuming this dictionary. Read it from the attribute when you need it.
+:::
 
 **Returns**
 
@@ -197,7 +238,7 @@ Get a dictionary with all statistics.
 
 **Return type**
 
-- Dict[[str](https://docs.python.org/3/library/stdtypes.html#str), [float](https://docs.python.org/3/library/functions.html#float)]
+- [dict](https://docs.python.org/3/library/stdtypes.html#dict)[[str](https://docs.python.org/3/library/stdtypes.html#str), [float](https://docs.python.org/3/library/functions.html#float)]
 
 ::: details Example
 

--- a/docs/api/stopwatch.md
+++ b/docs/api/stopwatch.md
@@ -7,21 +7,27 @@
 ```python
 def __init__(
     self,
-    name: Optional[str] = None,
+    name: str | None = None,
     print_report: bool = False,
-    precision: int = 2
+    precision: int = 2,
+    autostart: bool = True,
 ) -> None:
 ```
 
 **Parameters**
 
 - `name`: The name of the stopwatch, used for reporting.
-  - Type: Optional[[str](https://docs.python.org/3/library/stdtypes.html#str)]
-- `print_report`: This parameter is used to print elapsed time at the end of [with statement](https://www.geeksforgeeks.org/with-statement-in-python/).
+  - Type: [str](https://docs.python.org/3/library/stdtypes.html#str) | None
+  - Default: None
+- `print_report`: This parameter is used to print elapsed time at the end of [with statement](https://www.geeksforgeeks.org/with-statement-in-python/). The report is prefixed with `[module:function:line]`, pointing at where the stopwatch was created.
   - Type: [bool](https://docs.python.org/3/library/functions.html#bool)
   - Default: False
 - `precision`: The number of decimal places to use.
   - Type: [int](https://docs.python.org/3/library/functions.html#int)
+  - Default: 2
+- `autostart`: Whether to start measuring immediately. Pass `False` to measure only the blocks wrapped in [lap](#lap).
+  - Type: [bool](https://docs.python.org/3/library/functions.html#bool)
+  - Default: True
 
 ::: details Example
 
@@ -58,7 +64,32 @@ sw.precision = 0
 print(str(sw))  # 3s
 ```
 
+<br>
+
+```python
+sw = Stopwatch(autostart=False)
+sleep(0.5)              # setup work, not measured
+with sw.lap():
+    sleep(0.1)
+print(sw.laps[0].elapsed)  # 0.1
+
+# With the default autostart=True, the same code bills the 0.5s
+# to the first lap:
+sw = Stopwatch()
+sleep(0.5)
+with sw.lap():
+    sleep(0.1)
+print(sw.laps[0].elapsed)  # 0.6
+```
+
 :::
+
+## Supported operations
+
+```python
+str(sw)   # the elapsed time, formatted -> '2.00s'
+repr(sw)  # <Stopwatch name=None elapsed=2.0031827000002522>
+```
 
 ## Attributes
 
@@ -70,7 +101,7 @@ The name of the stopwatch. Can be set during initialization.
 
 **Type**
 
-- Optional[[str](https://docs.python.org/3/library/stdtypes.html#str)]
+- [str](https://docs.python.org/3/library/stdtypes.html#str) | None
 
 ::: details Example
 
@@ -108,7 +139,7 @@ The list of all stopwatch laps.
 
 **Type**
 
-- List[[Lap](/api/lap)]
+- list[[Lap](/api/lap)]
 
 ::: details Example
 
@@ -145,7 +176,8 @@ print(sw.elapsed)  # 1.0
 
 ### running
 
-True if the stopwatch is running, False if stopped.
+True while any lap is running, False when every lap is stopped. This includes
+the lap opened by a [lap](#lap) block, so it is True inside one.
 
 **Type**
 
@@ -158,6 +190,8 @@ sw = Stopwatch()
 print(sw.running)  # True
 sw.stop()
 print(sw.running)  # False
+
+print(Stopwatch(autostart=False).running)  # False
 ```
 
 :::
@@ -168,7 +202,7 @@ The statistics of the stopwatch.
 
 **Type**
 
-- Statistics
+- [Statistics](/api/statistics)
 
 ::: details Example
 
@@ -194,10 +228,12 @@ All methods of the `Stopwatch` class.
 def start(self) -> Stopwatch:
 ```
 
-Starts the stopwatch if not running.
+Starts the stopwatch if not running. Calling it on a stopwatch that is already
+running does nothing.
 
 ::: info
-This method is called automatically when the stopwatch is created.
+This method is called automatically when the stopwatch is created, unless you
+pass [autostart=False](#initialization).
 :::
 
 **Returns**
@@ -261,17 +297,65 @@ print(sw.running)  # False
 def lap(self) -> Iterator[None]:
 ```
 
-Context manager for create a new [lap](/api/lap).
+Context manager that records the block it wraps as its own [lap](/api/lap).
+
+The lap is always closed when the block ends, including when the block raises,
+so an exception cannot leave a lap running and skew every later reading.
+
+Nesting works: each `lap()` records a distinct lap, and the outer block keeps
+its own time.
+
+::: warning
+A stopwatch starts measuring as soon as it is created, and the first `lap()`
+takes over that lap instead of opening a second one — otherwise the time
+already on the clock would show up as an extra lap. That means any work between
+`Stopwatch()` and the first `lap()` is billed to the first lap. Use
+[autostart=False](#initialization) when you only want the `lap()` blocks
+measured.
+:::
 
 ::: details Example
 
 ```python
 with Stopwatch() as sw:
     for i in range(5):
-        with sw.lap(): // [!code focus]
+        with sw.lap(): # [!code focus]
             sleep(i / 10)
 print(f'{sw}')  # 1.00s
 print(len(sw.laps))  # 5
+```
+
+<br>
+
+Nested laps, each keeping its own time:
+
+```python
+sw = Stopwatch(autostart=False)
+with sw.lap():
+    sleep(0.1)
+    with sw.lap():
+        sleep(0.2)
+    sleep(0.1)
+print(len(sw.laps))         # 2
+print(sw.laps[0].elapsed)   # 0.4  (the outer block, including the inner one)
+print(sw.laps[1].elapsed)   # 0.2  (the inner block)
+```
+
+<br>
+
+The lap is closed even when the block raises:
+
+```python
+sw = Stopwatch(autostart=False)
+try:
+    with sw.lap():
+        sleep(0.1)
+        raise ValueError('boom')
+except ValueError:
+    pass
+sleep(0.3)
+print(sw.running)   # False
+print(sw.elapsed)   # 0.1  -- does not keep growing
 ```
 
 :::
@@ -357,7 +441,12 @@ with Stopwatch() as sw:
         with sw.lap():
             sleep(i / 10)
 print(sw.report())
-# [Stopwatch] total=1.0s, mean=0.2s, min=0.0s, median=0.2s, max=0.4s, dev=0.1s
+# [Stopwatch] total=1.00s, mean=0.20s, min=0.00s, median=0.20s, max=0.40s, dev=0.14s
 ```
+
+::: info
+The number of decimal places follows [precision](#precision). The mean, min,
+median, max and deviation are only included when there is more than one lap.
+:::
 
 :::

--- a/docs/api/stopwatch.md
+++ b/docs/api/stopwatch.md
@@ -1,6 +1,28 @@
+---
+title: Stopwatch
+description: API reference for the Stopwatch class — laps, elapsed time, statistics, reports, and the autostart option.
+---
+
 # Stopwatch
 
-**Source code: [stopwatch/stopwatch.py](https://github.com/devRMA/python-stopwatch2/blob/main/stopwatch/stopwatch.py)**
+Measures elapsed time, as a whole or split into [laps](/api/lap). It starts
+counting the moment you create it and can stop itself at the end of a `with`
+block.
+
+**Source:** [stopwatch/stopwatch.py](https://github.com/devRMA/python-stopwatch2/blob/main/stopwatch/stopwatch.py)
+
+```python
+from stopwatch import Stopwatch
+```
+
+## At a glance
+
+| What | Members |
+|---|---|
+| **Create** | [`Stopwatch(name, print_report, precision, autostart)`](#initialization) |
+| **Read** | [`elapsed`](#elapsed) · [`running`](#running) · [`laps`](#laps) · [`statistics`](#statistics) · [`str(sw)`](#supported-operations) |
+| **Measure** | [`lap()`](#lap) · [`start()`](#start) · [`stop()`](#stop) · [`reset()`](#reset) · [`restart()`](#restart) |
+| **Report** | [`report()`](#report) |
 
 ## Initialization
 
@@ -14,281 +36,162 @@ def __init__(
 ) -> None:
 ```
 
-**Parameters**
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str \| None` | `None` | Label shown in the reports, to tell several stopwatches apart. |
+| `print_report` | `bool` | `False` | Print the elapsed time when a `with` block ends. The line is prefixed with `[module:function:line]`, pointing at where the stopwatch was created. |
+| `precision` | `int` | `2` | Decimal places used when formatting. Can be changed later. |
+| `autostart` | `bool` | `True` | Start counting immediately. Pass `False` to measure only the blocks wrapped in [`lap()`](#lap). |
 
-- `name`: The name of the stopwatch, used for reporting.
-  - Type: [str](https://docs.python.org/3/library/stdtypes.html#str) | None
-  - Default: None
-- `print_report`: This parameter is used to print elapsed time at the end of [with statement](https://www.geeksforgeeks.org/with-statement-in-python/). The report is prefixed with `[module:function:line]`, pointing at where the stopwatch was created.
-  - Type: [bool](https://docs.python.org/3/library/functions.html#bool)
-  - Default: False
-- `precision`: The number of decimal places to use.
-  - Type: [int](https://docs.python.org/3/library/functions.html#int)
-  - Default: 2
-- `autostart`: Whether to start measuring immediately. Pass `False` to measure only the blocks wrapped in [lap](#lap).
-  - Type: [bool](https://docs.python.org/3/library/functions.html#bool)
-  - Default: True
-
-::: details Example
+A stopwatch is already running once created, so the simplest use is create,
+work, stop:
 
 ```python
-with Stopwatch('my stopwatch') as sw:
-    sleep(3)
-print(sw.report())
-# [Stopwatch#my stopwatch] total=3.00s
+from stopwatch import Stopwatch
+from time import sleep
+
+sw = Stopwatch()
+sleep(2)
+sw.stop()
+print(sw)  # 2.00s
 ```
 
-<br>
+Give it a name and let it report itself:
 
 ```python
-with Stopwatch('my custom message', True):
-    sleep(3)
-# [__main__:<module>:1] ~ 3.00s - my custom message
+from stopwatch import Stopwatch
+from time import sleep
+
+with Stopwatch('build', print_report=True):
+    sleep(1.2)
+
+# [__main__:<module>:4] ~ 1.20s - build
 ```
 
-<br>
+The `4` is the line the stopwatch was created on, which is how you tell several
+reports in one file apart.
 
-```python
-with Stopwatch(print_report=True):
-    sleep(3)
-# [__main__:<module>:1] ~ 3.00s
-```
-
-<br>
+`precision` applies to everything formatted, and is not fixed at creation:
 
 ```python
 with Stopwatch(precision=3) as sw:
-    sleep(3)
-print(str(sw))  # 3.000s
+    sleep(0.5)
+
+print(sw)          # 500.118ms
 sw.precision = 0
-print(str(sw))  # 3s
+print(sw)          # 500ms
 ```
-
-<br>
-
-```python
-sw = Stopwatch(autostart=False)
-sleep(0.5)              # setup work, not measured
-with sw.lap():
-    sleep(0.1)
-print(sw.laps[0].elapsed)  # 0.1
-
-# With the default autostart=True, the same code bills the 0.5s
-# to the first lap:
-sw = Stopwatch()
-sleep(0.5)
-with sw.lap():
-    sleep(0.1)
-print(sw.laps[0].elapsed)  # 0.6
-```
-
-:::
 
 ## Supported operations
 
 ```python
-str(sw)   # the elapsed time, formatted -> '2.00s'
-repr(sw)  # <Stopwatch name=None elapsed=2.0031827000002522>
+str(sw)   # '2.00s'                 formatted, honours precision
+repr(sw)  # <Stopwatch name=None elapsed=0.5001178499987873>
 ```
+
+`str()` is what f-strings use, so `f'took {sw}'` gives `took 2.00s`, while
+[`elapsed`](#elapsed) gives you the raw float.
 
 ## Attributes
 
-All attributes of the `Stopwatch` class.
-
 ### name
 
-The name of the stopwatch. Can be set during initialization.
+Label used in the reports. `None` when unnamed. Can be set at any time.
 
-**Type**
-
-- [str](https://docs.python.org/3/library/stdtypes.html#str) | None
-
-::: details Example
+**Type:** `str | None`
 
 ```python
 with Stopwatch('sw1') as sw:
     ...
+
 print(sw.name)  # sw1
 ```
 
-:::
-
 ### precision
 
-The number of decimal places to use. Can be set during initialization.
+Number of decimal places used when formatting. Defaults to `2`.
 
-**Type**
-
-- [int](https://docs.python.org/3/library/functions.html#int)
-- Default:
-  - 2
-
-::: details Example
+**Type:** [`int`](https://docs.python.org/3/library/functions.html#int)
 
 ```python
 with Stopwatch(precision=1) as sw:
     sleep(1)
-print(str(sw))  # 1.0s
-```
 
-:::
+print(sw)  # 1.0s
+```
 
 ### laps
 
-The list of all stopwatch laps.
+Every lap recorded so far, in order. A stopwatch that has never been started is
+empty.
 
-**Type**
-
-- list[[Lap](/api/lap)]
-
-::: details Example
+**Type:** `list[`[`Lap`](/api/lap)`]`
 
 ```python
-with Stopwatch() as sw:
-    with sw.lap():
-        sleep(1)
-    with sw.lap():
-        sleep(2)
-print(len(sw.laps))  # 2
-print(sw.laps[0].elapsed)  # 1.0
+sw = Stopwatch(autostart=False)
+with sw.lap():
+    sleep(1)
+with sw.lap():
+    sleep(2)
+
+print(len(sw.laps))         # 2
+print(sw.laps[0].elapsed)   # 1.0
 print(sw.laps[-1].elapsed)  # 2.0
 ```
 
-:::
-
 ### elapsed
 
-The elapsed time in seconds (sum of the elapsed time of all [laps](#laps)).
+Total time in seconds: the sum of every lap. Read it while the stopwatch is
+running and it reflects the clock at that moment, so it grows between reads.
 
-**Type**
-
-- [float](https://docs.python.org/3/library/functions.html#float)
-
-::: details Example
+**Type:** [`float`](https://docs.python.org/3/library/functions.html#float)
 
 ```python
-with Stopwatch(precision=1) as sw:
+with Stopwatch() as sw:
     sleep(1)
-print(sw.elapsed)  # 1.0
-```
 
-:::
+print(sw.elapsed)  # 1.000208768000448
+print(sw)          # 1.00s
+```
 
 ### running
 
-True while any lap is running, False when every lap is stopped. This includes
-the lap opened by a [lap](#lap) block, so it is True inside one.
+`True` while any lap is running. This includes the lap opened by a
+[`lap()`](#lap) block, so it is `True` inside one.
 
-**Type**
-
-- [bool](https://docs.python.org/3/library/functions.html#bool)
-
-::: details Example
+**Type:** [`bool`](https://docs.python.org/3/library/functions.html#bool)
 
 ```python
 sw = Stopwatch()
-print(sw.running)  # True
+print(sw.running)                          # True
 sw.stop()
-print(sw.running)  # False
+print(sw.running)                          # False
 
 print(Stopwatch(autostart=False).running)  # False
 ```
 
-:::
-
 ### statistics
 
-The statistics of the stopwatch.
+A [`Statistics`](/api/statistics) over the lap durations, rebuilt each time you
+read it.
 
-**Type**
-
-- [Statistics](/api/statistics)
-
-::: details Example
+**Type:** [`Statistics`](/api/statistics)
 
 ```python
-with Stopwatch() as sw:
-    for c in range(1, 6):
-        with sw.lap():
-            sleep(c / 10)
-print(sw.statistics.maximum)  # 0.5
-print(sw.statistics.minimum)  # 0.1
-print(sw.statistics.mean)  # 0.3
-```
+sw = Stopwatch(autostart=False)
+for c in range(1, 6):
+    with sw.lap():
+        sleep(c / 10)
 
-:::
+stats = sw.statistics
+print(len(stats))        # 5
+print(stats.mean)        # 0.3
+print(stats.minimum)     # 0.1
+print(stats.maximum)     # 0.5
+print(stats.stdev)       # 0.1414213562373095
+```
 
 ## Methods
-
-All methods of the `Stopwatch` class.
-
-### start
-
-```python
-def start(self) -> Stopwatch:
-```
-
-Starts the stopwatch if not running. Calling it on a stopwatch that is already
-running does nothing.
-
-::: info
-This method is called automatically when the stopwatch is created, unless you
-pass [autostart=False](#initialization).
-:::
-
-**Returns**
-
-- The self instance.
-
-**Return type**
-
-- [Stopwatch](#stopwatch)
-
-### stop
-
-```python
-def stop(self) -> Stopwatch:
-```
-
-Stops the stopwatch, freezing the duration.
-
-::: info
-This method is called automatically when you are using [with statement](https://www.geeksforgeeks.org/with-statement-in-python/).
-:::
-
-**Returns**
-
-- The self instance.
-
-**Return type**
-
-- [Stopwatch](#stopwatch)
-
-::: details Example
-
-```python
-sw = Stopwatch()
-sleep(2)
-sw.stop()
-print(sw.elapsed)  # 2.0
-sleep(1)
-print(sw.elapsed)  # 2.0
-sw.start()
-sleep(1)
-sw.stop()
-print(sw.elapsed)  # 3.0
-print(f'Time elapsed: {sw}')  # Time elapsed: 3.00s
-```
-
-<br>
-
-```python
-with Stopwatch() as sw:
-    print(sw.running)  # True
-print(sw.running)  # False
-```
-
-:::
 
 ### lap
 
@@ -297,37 +200,25 @@ print(sw.running)  # False
 def lap(self) -> Iterator[None]:
 ```
 
-Context manager that records the block it wraps as its own [lap](/api/lap).
+Records the block it wraps as its own [lap](/api/lap). This is the main way to
+measure: one lap per iteration, per step, per request.
 
-The lap is always closed when the block ends, including when the block raises,
-so an exception cannot leave a lap running and skew every later reading.
-
-Nesting works: each `lap()` records a distinct lap, and the outer block keeps
-its own time.
-
-::: warning
-A stopwatch starts measuring as soon as it is created, and the first `lap()`
-takes over that lap instead of opening a second one — otherwise the time
-already on the clock would show up as an extra lap. That means any work between
-`Stopwatch()` and the first `lap()` is billed to the first lap. Use
-[autostart=False](#initialization) when you only want the `lap()` blocks
-measured.
-:::
-
-::: details Example
+The lap is closed when the block ends, **including when the block raises**, so a
+failure cannot leave a lap running and skew every later reading. Nesting works
+too — each call records a distinct lap and the outer one still counts the time it
+spans.
 
 ```python
-with Stopwatch() as sw:
-    for i in range(5):
-        with sw.lap(): # [!code focus]
-            sleep(i / 10)
-print(f'{sw}')  # 1.00s
+sw = Stopwatch(autostart=False)
+for i in range(5):
+    with sw.lap():  # [!code focus]
+        sleep(i / 10)
+
+print(sw)            # 1.00s
 print(len(sw.laps))  # 5
 ```
 
-<br>
-
-Nested laps, each keeping its own time:
+Nested, each keeping its own time:
 
 ```python
 sw = Stopwatch(autostart=False)
@@ -336,14 +227,13 @@ with sw.lap():
     with sw.lap():
         sleep(0.2)
     sleep(0.1)
-print(len(sw.laps))         # 2
-print(sw.laps[0].elapsed)   # 0.4  (the outer block, including the inner one)
-print(sw.laps[1].elapsed)   # 0.2  (the inner block)
+
+print(len(sw.laps))        # 2
+print(sw.laps[0].elapsed)  # 0.4  the outer block, inner one included
+print(sw.laps[1].elapsed)  # 0.2  the inner block
 ```
 
-<br>
-
-The lap is closed even when the block raises:
+Closed even when the block raises:
 
 ```python
 sw = Stopwatch(autostart=False)
@@ -353,12 +243,57 @@ try:
         raise ValueError('boom')
 except ValueError:
     pass
+
 sleep(0.3)
-print(sw.running)   # False
-print(sw.elapsed)   # 0.1  -- does not keep growing
+print(sw.running)  # False
+print(sw.elapsed)  # 0.1   does not keep growing
 ```
 
+::: warning The first lap and `autostart`
+A stopwatch starts counting when it is created, and the first `lap()` takes over
+that already-running lap rather than opening a second one — otherwise the time
+already on the clock would show up as a phantom extra lap. The consequence is
+that work done between `Stopwatch()` and the first `lap()` lands in the first
+lap. Build it with `autostart=False` when you only want the `lap()` blocks
+measured.
 :::
+
+### start
+
+```python
+def start(self) -> Stopwatch:
+```
+
+Starts the stopwatch by opening a new lap. Does nothing if it is already
+running. Called for you at creation, unless you pass
+[`autostart=False`](#initialization).
+
+**Returns** the same instance, so it chains.
+
+### stop
+
+```python
+def stop(self) -> Stopwatch:
+```
+
+Stops the current lap, freezing the duration. Called for you when a `with` block
+ends.
+
+**Returns** the same instance.
+
+```python
+sw = Stopwatch()
+sleep(2)
+sw.stop()
+print(sw.elapsed)    # 2.0
+sleep(1)             # not counted
+print(sw.elapsed)    # 2.0
+sw.start()           # opens a second lap
+sleep(1)
+sw.stop()
+print(sw.elapsed)    # 3.0
+print(len(sw.laps))  # 2
+```
 
 ### reset
 
@@ -366,27 +301,20 @@ print(sw.elapsed)   # 0.1  -- does not keep growing
 def reset(self) -> Stopwatch:
 ```
 
-Resets the Stopwatch to 0 duration and stops it.
+Stops the stopwatch and throws every lap away, back to zero.
 
-**Returns**
-
-- The self instance.
-
-**Return type**
-
-- [Stopwatch](#stopwatch)
-
-::: details Example
+**Returns** the same instance.
 
 ```python
 with Stopwatch() as sw:
-    sleep(1)
-sw.reset()
-sleep(1)
-print(sw.elapsed)  # 0.0
-```
+    sleep(0.2)
 
-:::
+print(sw.elapsed)    # 0.2
+sw.reset()
+print(sw.elapsed)    # 0.0
+print(len(sw.laps))  # 0
+print(sw.running)    # False
+```
 
 ### restart
 
@@ -394,28 +322,21 @@ print(sw.elapsed)  # 0.0
 def restart(self) -> Stopwatch:
 ```
 
-Reset and start the stopwatch.
+[`reset()`](#reset) followed by [`start()`](#start): back to zero and counting
+again. This is what entering a `with` block does.
 
-**Returns**
-
-- The self instance.
-
-**Return type**
-
-- [Stopwatch](#stopwatch)
-
-::: details Example
+**Returns** the same instance.
 
 ```python
 sw = Stopwatch()
-sleep(1)
-print(str(sw))  # 1.00s
+sleep(0.2)
+print(sw)            # 200.15ms
 sw.restart()
-sleep(1)
-print(str(sw))  # 1.00s
+sleep(0.2)
+sw.stop()
+print(sw)            # 200.10ms
+print(len(sw.laps))  # 1
 ```
-
-:::
 
 ### report
 
@@ -423,30 +344,38 @@ print(str(sw))  # 1.00s
 def report(self) -> str:
 ```
 
-Return a report of the stopwatch statistics.
+A one-line summary of the laps, using [`precision`](#precision) for every
+number. With a single lap there is nothing to compare, so only the total is
+included.
 
-**Returns**
-
-- The string with the report.
-
-**Return type**
-
-- [str](https://docs.python.org/3/library/stdtypes.html#str)
-
-::: details Example
+**Returns** [`str`](https://docs.python.org/3/library/stdtypes.html#str)
 
 ```python
-with Stopwatch() as sw:
-    for i in range(5):
-        with sw.lap():
-            sleep(i / 10)
+sw = Stopwatch(autostart=False)
+for i in range(5):
+    with sw.lap():
+        sleep(i / 10)
+
 print(sw.report())
 # [Stopwatch] total=1.00s, mean=0.20s, min=0.00s, median=0.20s, max=0.40s, dev=0.14s
 ```
 
-::: info
-The number of decimal places follows [precision](#precision). The mean, min,
-median, max and deviation are only included when there is more than one lap.
-:::
+One lap, named:
 
-:::
+```python
+sw = Stopwatch('etl')
+sleep(0.3)
+sw.stop()
+
+print(sw.report())
+# [Stopwatch#etl] total=0.30s
+```
+
+## See also
+
+- [Measuring laps](/guide/measuring-laps) — the guide, with the reasoning behind
+  laps.
+- [`Lap`](/api/lap) — what each entry of [`laps`](#laps) is.
+- [`Statistics`](/api/statistics) — what [`statistics`](#statistics) returns.
+- [`profile`](/api/decorators#profile) — the same measurements, per function
+  call.

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,51 +1,63 @@
+---
+title: Utils
+description: API reference for format_elapsed_time — turn a duration in seconds into a readable string with the right unit.
+---
+
 # Utils
 
-**Source code: [stopwatch/utils.py](https://github.com/devRMA/python-stopwatch2/blob/main/stopwatch/utils.py)**
+**Source:** [stopwatch/utils.py](https://github.com/devRMA/python-stopwatch2/blob/main/stopwatch/utils.py)
 
 ## format_elapsed_time
+
+Turns a duration in seconds into a readable string, picking the unit from the
+size of the value. This is what [`str(sw)`](/api/stopwatch#supported-operations)
+and every report use, exported so you can format your own numbers the same way.
 
 ```python
 def format_elapsed_time(elapsed: float, precision: int = 2) -> str:
 ```
 
-Format the elapsed time in seconds to a human readable string.
+```python
+from stopwatch import format_elapsed_time
 
-The unit is picked from the magnitude of the value: seconds at 1s and above,
-milliseconds down to 1ms, and microseconds below that.
+print(format_elapsed_time(1.5))       # 1.50s
+print(format_elapsed_time(0.0801))    # 80.10ms
+print(format_elapsed_time(0.0000013)) # 1.30μs
+```
 
-**Parameters**
+| Range | Unit |
+|---|---|
+| 1s and above | `s` |
+| 1ms up to 1s | `ms` |
+| below 1ms | `μs` |
 
-- `elapsed`: The elapsed time in seconds.
-  - Type: [float](https://docs.python.org/3/library/functions.html#float)
-- `precision`: The number of decimal places to use.
-  - Type: [int](https://docs.python.org/3/library/functions.html#int)
-  - Default: 2
+### Parameters
 
-**Returns**
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `elapsed` | [`float`](https://docs.python.org/3/library/functions.html#float) | — | The duration, in seconds. |
+| `precision` | [`int`](https://docs.python.org/3/library/functions.html#int) | `2` | Decimal places. |
 
-- The formatted elapsed time.
+**Returns** [`str`](https://docs.python.org/3/library/stdtypes.html#str)
 
-**Return type**
-
-- [str](https://docs.python.org/3/library/stdtypes.html#str)
-
-::: details Example
+### Precision
 
 ```python
 from stopwatch import format_elapsed_time
 
-print(format_elapsed_time(1, 2))  # 1.00s
-print(format_elapsed_time(1, 4))  # 1.0000s
-print(format_elapsed_time(1, 0))  # 1s
-print(format_elapsed_time(0.1, 0))  # 100ms
-print(format_elapsed_time(0.001, 0))  # 1ms
-print(format_elapsed_time(0.0001, 0))  # 100μs
+print(format_elapsed_time(1, 2))         # 1.00s
+print(format_elapsed_time(1, 4))         # 1.0000s
+print(format_elapsed_time(1, 0))         # 1s
+print(format_elapsed_time(0.1, 0))       # 100ms
+print(format_elapsed_time(0.001, 0))     # 1ms
+print(format_elapsed_time(0.0001, 0))    # 100μs
 print(format_elapsed_time(0.000001, 0))  # 1μs
 ```
 
-<br>
+### Negative and zero
 
-Negative values keep the unit of their magnitude:
+The unit comes from the magnitude, so a negative duration keeps the unit its
+size deserves rather than collapsing into microseconds.
 
 ```python
 from stopwatch import format_elapsed_time
@@ -56,4 +68,22 @@ print(format_elapsed_time(-0.000001))  # -1.00μs
 print(format_elapsed_time(0))          # 0.00μs
 ```
 
-:::
+### Formatting statistics
+
+Every [`Statistics`](/api/statistics) value is in seconds, so this is how you
+make one readable:
+
+```python
+from stopwatch import Statistics, format_elapsed_time
+
+stats = Statistics([0.1, 0.2, 0.3, 0.4, 0.5])
+
+print(format_elapsed_time(stats.mean))   # 300.00ms
+print(format_elapsed_time(stats.stdev))  # 141.42ms
+```
+
+## See also
+
+- [`Statistics`](/api/statistics) — the values you will want to format.
+- [`Stopwatch.precision`](/api/stopwatch#precision) — the same setting, applied
+  to a stopwatch's own output.

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -10,12 +10,15 @@ def format_elapsed_time(elapsed: float, precision: int = 2) -> str:
 
 Format the elapsed time in seconds to a human readable string.
 
+The unit is picked from the magnitude of the value: seconds at 1s and above,
+milliseconds down to 1ms, and microseconds below that.
+
 **Parameters**
 
 - `elapsed`: The elapsed time in seconds.
   - Type: [float](https://docs.python.org/3/library/functions.html#float)
 - `precision`: The number of decimal places to use.
-  - Type: [float](https://docs.python.org/3/library/functions.html#float)
+  - Type: [int](https://docs.python.org/3/library/functions.html#int)
   - Default: 2
 
 **Returns**
@@ -38,6 +41,19 @@ print(format_elapsed_time(0.1, 0))  # 100ms
 print(format_elapsed_time(0.001, 0))  # 1ms
 print(format_elapsed_time(0.0001, 0))  # 100μs
 print(format_elapsed_time(0.000001, 0))  # 1μs
+```
+
+<br>
+
+Negative values keep the unit of their magnitude:
+
+```python
+from stopwatch import format_elapsed_time
+
+print(format_elapsed_time(-1))         # -1.00s
+print(format_elapsed_time(-0.1))       # -100.00ms
+print(format_elapsed_time(-0.000001))  # -1.00μs
+print(format_elapsed_time(0))          # 0.00μs
 ```
 
 :::

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,3 +1,8 @@
+---
+title: Getting Started
+description: Install python-stopwatch2 and take your first measurement in three lines. Requires Python 3.10 or newer.
+---
+
 # Getting Started
 
 This section will help you install the library and basic usage of the stopwatch class.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -2,6 +2,14 @@
 
 This section will help you install the library and basic usage of the stopwatch class.
 
+::: info Requirements
+Python **3.10 or newer**. The only runtime dependency is
+[colorama](https://pypi.org/project/colorama/), for the colored reports.
+
+Using Python 3.7, 3.8 or 3.9? Those are end-of-life upstream and supported only
+up to `python-stopwatch2` 1.1.1.
+:::
+
 - **Step. 1:** Install the library.
 
   ::: code-group
@@ -64,3 +72,12 @@ This section will help you install the library and basic usage of the stopwatch 
   sw.stop()
   print(f'Time elapsed: {sw}')  # Time elapsed: 2.00s
   ```
+
+- **Where to go next**
+
+  - [With statement](/guide/with-statement) — let the stopwatch start and stop
+    itself around a block.
+  - [Measuring laps](/guide/measuring-laps) — time each iteration separately and
+    get statistics across them.
+  - [Profiling a function](/guide/profiling-function) — measure every call to a
+    function with a decorator.

--- a/docs/guide/measuring-laps.md
+++ b/docs/guide/measuring-laps.md
@@ -1,3 +1,8 @@
+---
+title: Measuring laps
+description: Time each iteration of a loop separately with laps, get mean, median and standard deviation across them, and nest laps to split a step out of a larger one.
+---
+
 # Measuring laps
 
 A lap is one measured interval. Instead of a single total, laps let you time

--- a/docs/guide/measuring-laps.md
+++ b/docs/guide/measuring-laps.md
@@ -1,0 +1,146 @@
+# Measuring laps
+
+A lap is one measured interval. Instead of a single total, laps let you time
+each iteration of a loop separately and then look at the spread across them —
+the mean, the slowest one, the deviation.
+
+## Timing each iteration
+
+Wrap the part you want measured in [`sw.lap()`](/api/stopwatch#lap):
+
+```python{5}
+from stopwatch import Stopwatch
+from time import sleep
+
+sw = Stopwatch(autostart=False)
+for delay in [0.1, 0.2, 0.3]:
+    with sw.lap():
+        sleep(delay)
+
+print(f'total: {sw}')  # total: 600.59ms
+for i, lap in enumerate(sw.laps):
+    print(f'  lap {i}: {lap.elapsed:.3f}s')
+#   lap 0: 0.100s
+#   lap 1: 0.200s
+#   lap 2: 0.300s
+```
+
+Everything outside the `with` block — the loop machinery, whatever else the
+iteration does — stays out of the measurement.
+
+## Leaving setup out
+
+A stopwatch starts measuring the moment it is created, and the first `lap()`
+takes over that already-running lap rather than opening a second one. That is
+what keeps a stray extra lap out of your results, but it also means anything
+you do between `Stopwatch()` and the first `lap()` lands in the first lap.
+
+Pass `autostart=False` when the stopwatch should sit idle until the first lap:
+
+```python
+sw = Stopwatch(autostart=False)   # [!code focus]
+load_config()                     # 0.5s, not measured
+with sw.lap():
+    do_work()                     # 0.1s
+
+# autostart=False -> lap[0]=0.10s  total=0.10s
+# autostart=True  -> lap[0]=0.60s  total=0.60s
+```
+
+## Statistics across laps
+
+[`sw.statistics`](/api/statistics) summarises the laps:
+
+```python
+from stopwatch import Stopwatch
+from time import sleep
+
+sw = Stopwatch(autostart=False)
+for delay in [0.1, 0.2, 0.3, 0.4, 0.5]:
+    with sw.lap():
+        sleep(delay)
+
+stats = sw.statistics
+print(len(stats))       # 5
+print(stats.mean)       # 0.3
+print(stats.minimum)    # 0.1
+print(stats.median)     # 0.3
+print(stats.maximum)    # 0.5
+print(stats.total)      # 1.501
+print(stats.stdev)      # 0.141
+```
+
+Or get the whole thing as one line with
+[`sw.report()`](/api/stopwatch#report):
+
+```python
+print(sw.report())
+# [Stopwatch] total=1.50s, mean=0.30s, min=0.10s, median=0.30s, max=0.50s, dev=0.14s
+```
+
+::: info
+`report()` only includes the mean, min, median, max and deviation when there is
+more than one lap. With a single lap there is nothing to compare, so it prints
+just the total.
+:::
+
+## Nesting
+
+Laps nest. Each `lap()` records its own interval, and the outer one still counts
+all the time it spans, including the inner block:
+
+```python
+sw = Stopwatch(autostart=False)
+with sw.lap():
+    sleep(0.1)
+    with sw.lap():
+        sleep(0.2)
+    sleep(0.1)
+
+print(len(sw.laps))        # 2
+print(sw.laps[0].elapsed)  # 0.4  the outer block
+print(sw.laps[1].elapsed)  # 0.2  the inner block
+```
+
+This is useful for splitting a step out of a larger one — timing a database
+call inside a request, for instance — without losing the total.
+
+## Exceptions
+
+A lap is closed when its block ends, whether it ends normally or by raising.
+You do not need a `try`/`finally` of your own:
+
+```python
+sw = Stopwatch(autostart=False)
+try:
+    with sw.lap():
+        sleep(0.1)
+        raise ValueError('boom')
+except ValueError:
+    pass
+
+print(sw.running)   # False
+print(sw.elapsed)   # 0.1
+```
+
+## Starting and stopping by hand
+
+`lap()` is the recommended way, but [`start()`](/api/stopwatch#start) and
+[`stop()`](/api/stopwatch#stop) are there when the interval does not map to a
+block:
+
+```python
+sw = Stopwatch()
+sleep(1)
+sw.stop()
+sleep(1)          # not counted
+print(sw.elapsed)  # ~1.0
+sw.start()         # opens a new lap
+sleep(1)
+sw.stop()
+print(sw.elapsed)  # ~2.0
+print(len(sw.laps))  # 2
+```
+
+[`reset()`](/api/stopwatch#reset) throws the laps away and stops the stopwatch;
+[`restart()`](/api/stopwatch#restart) resets and starts a fresh lap.

--- a/docs/guide/other-libraries.md
+++ b/docs/guide/other-libraries.md
@@ -2,6 +2,13 @@
 
 There are other timer libraries for python, here are some differences.
 
+::: info
+`python-stopwatch2` started as a fork of
+[python-stopwatch](https://pypi.org/project/python-stopwatch/), adding static
+typing and the pieces below. The other projects may have moved on since this
+table was written — check their repositories before relying on it.
+:::
+
 |                             Library                              |     Unit tests     |     Statistics     |        Laps        |   Static Typing    |        Docs        |     Docstring      |
 | :--------------------------------------------------------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
 |      [stopwatch.py](https://pypi.org/project/stopwatch.py/)      | :white_check_mark: |        :x:         |        :x:         |        :x:         |        :x:         |        :x:         |

--- a/docs/guide/other-libraries.md
+++ b/docs/guide/other-libraries.md
@@ -1,3 +1,8 @@
+---
+title: Other libraries
+description: How python-stopwatch2 compares with stopwatch.py and the original python-stopwatch, and when to just use time.perf_counter.
+---
+
 # Other libraries
 
 There are other timer libraries for python, here are some differences.

--- a/docs/guide/profiling-function.md
+++ b/docs/guide/profiling-function.md
@@ -1,3 +1,8 @@
+---
+title: Profiling a function
+description: Measure every call to a function with the profile decorator, including async def, with periodic statistics reports.
+---
+
 # Profiling a function
 
 Use the [profile](/api/decorators#profile) decorator to measure every call to a

--- a/docs/guide/profiling-function.md
+++ b/docs/guide/profiling-function.md
@@ -1,6 +1,8 @@
 # Profiling a function
 
-You can use this decorator to profile a function. It will print a report every time the function is called and, at the end of the execution, the final report will be printed.
+Use the [profile](/api/decorators#profile) decorator to measure every call to a
+function. By default it prints a running report on each call, so you watch the
+numbers settle as the function is exercised.
 
 ```python{5}
 from stopwatch import profile
@@ -22,5 +24,45 @@ print('end')
 # [__main__#My function] hits=4, mean=250.30ms, min=100.14ms, median=250.30ms, max=400.44ms, dev=111.92ms
 # [__main__#My function] hits=5, mean=300.35ms, min=100.14ms, median=300.35ms, max=500.55ms, dev=141.56ms
 # end
-# [__main__#My function] hits=5, mean=300.35ms, min=100.14ms, median=300.35ms, max=500.55ms, dev=141.56ms
 ```
+
+Reporting on every call gets noisy for a function called often. Pass
+`report_every` to report periodically, or `None` to report only once when the
+process exits:
+
+```python
+@profile(report_every=100)
+def hot_path() -> None:
+    ...
+
+@profile(report_every=None)
+def quiet() -> None:
+    ...
+```
+
+`async def` functions work too, and are measured across the `await` rather than
+just the creation of the coroutine:
+
+```python
+import asyncio
+from stopwatch import profile
+
+
+@profile(name='fetch')
+async def fetch() -> str:
+    await asyncio.sleep(0.2)
+    return 'ok'
+
+
+asyncio.run(fetch())
+
+# [__main__#fetch] hits=1, mean=200.47ms, min=200.47ms, median=200.47ms, max=200.47ms, dev=0.00μs
+```
+
+A call that raises is still recorded, so a function that starts failing does not
+quietly vanish from the report.
+
+::: tip
+Need to measure part of a function rather than the whole thing? Use
+[laps](/guide/measuring-laps) instead.
+:::

--- a/docs/guide/with-statement.md
+++ b/docs/guide/with-statement.md
@@ -22,3 +22,22 @@ with Stopwatch(print_report=True):
 
 # [__main__:<module>:4] ~ 2.00s
 ```
+
+The prefix is `[module:function:line]` and points at the line where the
+stopwatch was created, so you can tell several reports apart. Pass a name to
+label it as well:
+
+```python{4}
+from stopwatch import Stopwatch
+from time import sleep
+
+with Stopwatch('my custom message', print_report=True):
+    sleep(1)
+
+# [__main__:<module>:4] ~ 1.00s - my custom message
+```
+
+::: tip
+Timing several iterations instead of one block? See
+[measuring laps](/guide/measuring-laps).
+:::

--- a/docs/guide/with-statement.md
+++ b/docs/guide/with-statement.md
@@ -1,3 +1,8 @@
+---
+title: With statement
+description: Use a Stopwatch as a context manager so it starts and stops itself around a block, and have it print the report for you.
+---
+
 # With statement
 
 You can use the Stopwatch Class with the [with statement](https://www.geeksforgeeks.org/with-statement-in-python/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ description: A simple library to measure code performance.
 hero:
   name: Python Stopwatch 2
   text: A simple library to measure code performance.
+  tagline: Time a block, a loop, or every call to a function — in three lines, with statistics.
   image:
     src: /logo_shadow.svg
     alt: Python Stopwatch 2 Logo
@@ -15,6 +16,9 @@ hero:
       text: Get Started
       link: /guide/getting-started
     - theme: alt
+      text: API Reference
+      link: /api/stopwatch
+    - theme: alt
       text: Demo
       link: https://replit.com/@devRMA/Python-Stopwatch-2-Example#main.py
     - theme: alt
@@ -22,14 +26,29 @@ hero:
       link: https://github.com/devRMA/python-stopwatch2
 
 features:
+  - icon: ⏱️
+    title: Three ways to measure
+    details: A context manager around a block, laps inside a loop, or a decorator on a function.
+    link: /guide/measuring-laps
+    linkText: Measuring laps
+  - icon: 📊
+    title: Statistics, not just totals
+    details: Mean, median, min, max and standard deviation across every lap or call, formatted for you.
+    link: /api/statistics
+    linkText: Statistics API
   - icon: 🔑
-    title: Typing Hinting
-    details: All methods are statically typed to help you with coding.
+    title: Fully typed
+    details: Ships a py.typed marker, so mypy and your editor see the real signatures. Checked under mypy strict.
+    link: /api/stopwatch
+    linkText: Stopwatch API
   - icon: ☂️
-    title: Code Coverage
-    details: All code is covered with unit tests.
-  - icon: 💡
-    title: Easy to use
-    details: Simple and easy to use.
+    title: Tested to 100%
+    details: 100% line and branch coverage, on Python 3.10 through 3.14, on Linux and Windows.
+  - icon: 🪶
+    title: One dependency
+    details: Only colorama, for the colored reports. Nothing else comes along for the ride.
+  - icon: 🎯
+    title: Cheap to use
+    details: Measuring costs under a microsecond of overhead, so the instrument stays out of the measurement.
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,54 +1,149 @@
 ---
 layout: home
 
-title: Stopwatch 2
-description: A simple library to measure code performance.
+title: Python Stopwatch 2
+titleTemplate: Measure Python code performance
+description: A small, fully typed Python stopwatch and profiler. Time a block with a context manager, time each iteration with laps, or time every call to a function with a decorator — with mean, median and standard deviation included.
+
+head:
+  - - meta
+    - name: keywords
+      content: python stopwatch, python timer, python profiler, measure execution time python, benchmark python code, python performance, timeit alternative, python decorator timer, context manager timer
+  - - link
+    - rel: canonical
+      href: https://stopwatch2.vercel.app/
 
 hero:
   name: Python Stopwatch 2
-  text: A simple library to measure code performance.
-  tagline: Time a block, a loop, or every call to a function — in three lines, with statistics.
+  text: Measure code performance.
+  tagline: Time a block, every iteration of a loop, or every call to a function. Three lines, real statistics, under a microsecond of overhead.
   image:
     src: /logo_shadow.svg
-    alt: Python Stopwatch 2 Logo
+    alt: Python Stopwatch 2 logo, a stopwatch dial
   actions:
     - theme: brand
       text: Get Started
       link: /guide/getting-started
     - theme: alt
+      text: Why laps?
+      link: /guide/measuring-laps
+    - theme: alt
       text: API Reference
       link: /api/stopwatch
     - theme: alt
-      text: Demo
-      link: https://replit.com/@devRMA/Python-Stopwatch-2-Example#main.py
-    - theme: alt
-      text: View on GitHub
+      text: GitHub
       link: https://github.com/devRMA/python-stopwatch2
 
 features:
   - icon: ⏱️
     title: Three ways to measure
-    details: A context manager around a block, laps inside a loop, or a decorator on a function.
+    details: A context manager around a block, laps inside a loop, or a decorator on a function. Pick whichever fits the code you already have.
     link: /guide/measuring-laps
     linkText: Measuring laps
   - icon: 📊
     title: Statistics, not just totals
-    details: Mean, median, min, max and standard deviation across every lap or call, formatted for you.
+    details: Mean, median, min, max and standard deviation across every lap or call, already formatted into readable units.
     link: /api/statistics
     linkText: Statistics API
   - icon: 🔑
     title: Fully typed
-    details: Ships a py.typed marker, so mypy and your editor see the real signatures. Checked under mypy strict.
+    details: Ships a py.typed marker, so mypy and your editor see the real signatures. The library itself is checked under mypy strict.
     link: /api/stopwatch
     linkText: Stopwatch API
+  - icon: 🎯
+    title: Cheap enough to leave in
+    details: Creating a reporting stopwatch costs under a microsecond, so the instrument stays out of the measurement it is reporting.
+  - icon: 🪶
+    title: One dependency
+    details: Only colorama, for the coloured reports. Nothing else comes along for the ride.
   - icon: ☂️
     title: Tested to 100%
     details: 100% line and branch coverage, on Python 3.10 through 3.14, on Linux and Windows.
-  - icon: 🪶
-    title: One dependency
-    details: Only colorama, for the colored reports. Nothing else comes along for the ride.
-  - icon: 🎯
-    title: Cheap to use
-    details: Measuring costs under a microsecond of overhead, so the instrument stays out of the measurement.
-
 ---
+
+## Install
+
+::: code-group
+
+```bash [pip]
+python3 -m pip install python-stopwatch2
+```
+
+```bash [poetry]
+poetry add python-stopwatch2
+```
+
+```bash [uv]
+uv add python-stopwatch2
+```
+
+:::
+
+Requires Python 3.10 or newer.
+
+## Pick the shape that fits your code
+
+::: code-group
+
+```python [A block]
+from stopwatch import Stopwatch
+
+with Stopwatch(print_report=True):
+    build_the_index()
+
+# [__main__:<module>:4] ~ 1.20s
+```
+
+```python [Each iteration]
+from stopwatch import Stopwatch
+
+sw = Stopwatch(autostart=False)
+for document in documents:
+    with sw.lap():
+        index(document)
+
+print(sw.report())
+# [Stopwatch] total=0.60s, mean=0.20s, min=0.10s, median=0.20s, max=0.30s, dev=0.08s
+```
+
+```python [Every call]
+from stopwatch import profile
+
+@profile()
+def parse(payload: bytes) -> dict:
+    ...
+
+# [__main__#parse] hits=1, mean=80.13ms, min=80.13ms, median=80.13ms, max=80.13ms, dev=0.00μs
+# [__main__#parse] hits=2, mean=100.19ms, min=80.13ms, median=100.19ms, max=120.24ms, dev=20.06ms
+# [__main__#parse] hits=3, mean=100.16ms, min=80.13ms, median=100.11ms, max=120.24ms, dev=16.38ms
+```
+
+:::
+
+## Why not `time.perf_counter()`?
+
+For a single measurement, use `perf_counter` — it is two lines and no dependency.
+This library earns its place when you want the parts around the measurement:
+
+- The stopwatch **stops itself**, including when the block raises, so a failure
+  cannot leave you reading a number that keeps growing.
+- **Laps** give you one measurement per iteration instead of a total you then
+  have to divide.
+- **Statistics** come with it: mean, median, min, max, standard deviation.
+- **Units** are picked for you — `1.20s`, `80.13ms`, `1.32μs` — instead of
+  `0.08012700000000141`.
+- The **report says where it came from**, so several timers in one file stay
+  apart.
+
+Compared with `timeit`, this measures your real code in place rather than a
+snippet run in isolation, and compared with `cProfile` it measures only what you
+asked about instead of everything.
+
+## Next
+
+- [Getting Started](/guide/getting-started) — install and the first measurement.
+- [With statement](/guide/with-statement) — the context manager in detail.
+- [Measuring laps](/guide/measuring-laps) — loops, statistics and nesting.
+- [Profiling a function](/guide/profiling-function) — the decorator, including
+  `async def`.
+- [Other libraries](/guide/other-libraries) — how this compares.

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://stopwatch2.vercel.app/sitemap.xml

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "serve": "vitepress serve docs"
   },
   "devDependencies": {
-    "vitepress": "^1.0.0-rc.21"
+    "vitepress": "2.0.0-alpha.19"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,628 +2,940 @@
 # yarn lockfile v1
 
 
-"@algolia/autocomplete-core@1.9.3":
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz#1d56482a768c33aae0868c8533049e02e8961be7"
-  integrity sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
+
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
+
+"@babel/parser@^7.29.7":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.8.tgz#9653716a2f10c677b98fbc63d4bfb000c302cf17"
+  integrity sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==
   dependencies:
-    "@algolia/autocomplete-plugin-algolia-insights" "1.9.3"
-    "@algolia/autocomplete-shared" "1.9.3"
+    "@babel/types" "^7.29.8"
 
-"@algolia/autocomplete-plugin-algolia-insights@1.9.3":
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz#9b7f8641052c8ead6d66c1623d444cbe19dde587"
-  integrity sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==
+"@babel/types@^7.29.8":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.8.tgz#1229eef31d85156d70fa3f4cd859376d0eaf6863"
+  integrity sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==
   dependencies:
-    "@algolia/autocomplete-shared" "1.9.3"
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
 
-"@algolia/autocomplete-preset-algolia@1.9.3":
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz#64cca4a4304cfcad2cf730e83067e0c1b2f485da"
-  integrity sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==
+"@docsearch/css@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-4.7.0.tgz#d6d93c6ddf5e813a3ea09da719e150c222693a5c"
+  integrity sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==
+
+"@docsearch/js@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@docsearch/js/-/js-4.7.0.tgz#6294b040c7a0e461f61120f54b0dc770af3916bf"
+  integrity sha512-x5lCqu1tetgsJFkjQ6VSocbHldsRkGEgwg5N98Vx21sq/V5wcmj4u226PY9k+TEpIgQ772zlYbPLTPicWyGnpA==
+
+"@docsearch/sidepanel-js@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@docsearch/sidepanel-js/-/sidepanel-js-4.7.0.tgz#d767ca71f72c4673db87229f64634786a255bb08"
+  integrity sha512-A8r34jCU8kcIk2viECEn2msA28ojUF1BLi/3v5OWWc5G2N3jOuuumBXoeYjfr8dA0UxgFSy5R2bt12dnFJQSyA==
+
+"@emnapi/core@2.0.0-alpha.3":
+  version "2.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-2.0.0-alpha.3.tgz#049ace671f30274d6a4d161d3b771138b862f704"
+  integrity sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==
   dependencies:
-    "@algolia/autocomplete-shared" "1.9.3"
+    "@emnapi/wasi-threads" "2.0.1"
+    tslib "^2.4.0"
 
-"@algolia/autocomplete-shared@1.9.3":
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz#2e22e830d36f0a9cf2c0ccd3c7f6d59435b77dfa"
-  integrity sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==
-
-"@algolia/cache-browser-local-storage@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.20.0.tgz#357318242fc542ffce41d6eb5b4a9b402921b0bb"
-  integrity sha512-uujahcBt4DxduBTvYdwO3sBfHuJvJokiC3BP1+O70fglmE1ShkH8lpXqZBac1rrU3FnNYSUs4pL9lBdTKeRPOQ==
+"@emnapi/runtime@2.0.0-alpha.3":
+  version "2.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz#aef04c35c9a83c23ab0f251f03095440edd7ad5f"
+  integrity sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==
   dependencies:
-    "@algolia/cache-common" "4.20.0"
+    tslib "^2.4.0"
 
-"@algolia/cache-common@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.20.0.tgz#ec52230509fce891091ffd0d890618bcdc2fa20d"
-  integrity sha512-vCfxauaZutL3NImzB2G9LjLt36vKAckc6DhMp05An14kVo8F1Yofb6SIl6U3SaEz8pG2QOB9ptwM5c+zGevwIQ==
-
-"@algolia/cache-in-memory@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/cache-in-memory/-/cache-in-memory-4.20.0.tgz#5f18d057bd6b3b075022df085c4f83bcca4e3e67"
-  integrity sha512-Wm9ak/IaacAZXS4mB3+qF/KCoVSBV6aLgIGFEtQtJwjv64g4ePMapORGmCyulCFwfePaRAtcaTbMcJF+voc/bg==
+"@emnapi/wasi-threads@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz#1c92919328be1f6ab79fb60a67ccf3d2e62cd48b"
+  integrity sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==
   dependencies:
-    "@algolia/cache-common" "4.20.0"
+    tslib "^2.4.0"
 
-"@algolia/client-account@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-account/-/client-account-4.20.0.tgz#23ce0b4cffd63100fb7c1aa1c67a4494de5bd645"
-  integrity sha512-GGToLQvrwo7am4zVkZTnKa72pheQeez/16sURDWm7Seyz+HUxKi3BM6fthVVPUEBhtJ0reyVtuK9ArmnaKl10Q==
+"@iconify-json/simple-icons@^1.2.92":
+  version "1.2.92"
+  resolved "https://registry.yarnpkg.com/@iconify-json/simple-icons/-/simple-icons-1.2.92.tgz#e055968bdea9f97a87d9576ceac1a6c85366d636"
+  integrity sha512-hR0ozxR97t1dzWw+esoxFijZ15gagt7EIgF3CNifu2yICXhS7gnun4Y+j+odJQtNSl7wvqMdoLbViIShwe/fdw==
   dependencies:
-    "@algolia/client-common" "4.20.0"
-    "@algolia/client-search" "4.20.0"
-    "@algolia/transporter" "4.20.0"
+    "@iconify/types" "*"
 
-"@algolia/client-analytics@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-4.20.0.tgz#0aa6bef35d3a41ac3991b3f46fcd0bf00d276fa9"
-  integrity sha512-EIr+PdFMOallRdBTHHdKI3CstslgLORQG7844Mq84ib5oVFRVASuuPmG4bXBgiDbcsMLUeOC6zRVJhv1KWI0ug==
+"@iconify/types@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@iconify/types/-/types-2.0.0.tgz#ab0e9ea681d6c8a1214f30cd741fe3a20cc57f57"
+  integrity sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
+
+"@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
+"@napi-rs/wasm-runtime@^1.2.0":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz#c70706532e5827c0932ca6bf43ee2c512f29c639"
+  integrity sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==
   dependencies:
-    "@algolia/client-common" "4.20.0"
-    "@algolia/client-search" "4.20.0"
-    "@algolia/requester-common" "4.20.0"
-    "@algolia/transporter" "4.20.0"
+    "@tybys/wasm-util" "^0.10.3"
 
-"@algolia/client-common@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.20.0.tgz#ca60f04466515548651c4371a742fbb8971790ef"
-  integrity sha512-P3WgMdEss915p+knMMSd/fwiHRHKvDu4DYRrCRaBrsfFw7EQHon+EbRSm4QisS9NYdxbS04kcvNoavVGthyfqQ==
+"@oxc-project/types@=0.142.0":
+  version "0.142.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.142.0.tgz#0b4bd7841ef3dd267a69184b97452cc0b313fb52"
+  integrity sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==
+
+"@rolldown/binding-android-arm64@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz#dbc5a2453c063aa9b2974410d19b4be2e730856f"
+  integrity sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==
+
+"@rolldown/binding-darwin-arm64@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz#dd43dc12d5acd6a34edbd48cdf3008f5d4c52e2a"
+  integrity sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==
+
+"@rolldown/binding-darwin-x64@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz#00b32d5e0adba8aab6925633280ed1bf6d90c1d2"
+  integrity sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==
+
+"@rolldown/binding-freebsd-x64@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz#0884face257d2763024754abae947e1c0b7b6c24"
+  integrity sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==
+
+"@rolldown/binding-linux-arm-gnueabihf@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz#a82580ac5cf3030c65ccf6181326d64f91889524"
+  integrity sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==
+
+"@rolldown/binding-linux-arm64-gnu@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz#5221b6c7eab55f82d776e65f9146d387cec3791e"
+  integrity sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==
+
+"@rolldown/binding-linux-arm64-musl@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz#3552c35275daad1f1553f1f29452aa62bffbd120"
+  integrity sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==
+
+"@rolldown/binding-linux-ppc64-gnu@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz#6b4972d32614b70885c5bf580695fb1e365b5313"
+  integrity sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==
+
+"@rolldown/binding-linux-s390x-gnu@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz#42ebada72e617003e30b67ac9b4afff66a75b15a"
+  integrity sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==
+
+"@rolldown/binding-linux-x64-gnu@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz#37734bbf4b90cf39da5301f18b6f089b65a745d9"
+  integrity sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==
+
+"@rolldown/binding-linux-x64-musl@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz#95170913f28700fbd56c8d85649e3960abe5632f"
+  integrity sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==
+
+"@rolldown/binding-openharmony-arm64@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz#d163a5fe25d3542b7b325c05e0211825f42d2b5c"
+  integrity sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==
+
+"@rolldown/binding-wasm32-wasi@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz#8333205b61997d298fb433214a99b01874459342"
+  integrity sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==
   dependencies:
-    "@algolia/requester-common" "4.20.0"
-    "@algolia/transporter" "4.20.0"
+    "@emnapi/core" "2.0.0-alpha.3"
+    "@emnapi/runtime" "2.0.0-alpha.3"
+    "@napi-rs/wasm-runtime" "^1.2.0"
 
-"@algolia/client-personalization@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-personalization/-/client-personalization-4.20.0.tgz#ca81308e8ad0db3b27458b78355f124f29657181"
-  integrity sha512-N9+zx0tWOQsLc3K4PVRDV8GUeOLAY0i445En79Pr3zWB+m67V+n/8w4Kw1C5LlbHDDJcyhMMIlqezh6BEk7xAQ==
+"@rolldown/binding-win32-arm64-msvc@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz#c730559e7d74fa9ba24106d9104e7c8dc25f2236"
+  integrity sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==
+
+"@rolldown/binding-win32-x64-msvc@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz#ea040d8719fe26c8b0d781081329b20a1606a006"
+  integrity sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==
+
+"@rolldown/pluginutils@^1.0.0", "@rolldown/pluginutils@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
+  integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
+
+"@shikijs/core@4.4.1", "@shikijs/core@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/core/-/core-4.4.1.tgz#91eaf0073b848a668dbd1b21cbb6a37baf6b7b16"
+  integrity sha512-VeR2CY6Nn9/WbisoYLOQZ7HZOnwTrpBuOw4wExjqLnBCi62BNWynBUO6K2uPIASPFJwAv7cX1fUu+LrPlSstcw==
   dependencies:
-    "@algolia/client-common" "4.20.0"
-    "@algolia/requester-common" "4.20.0"
-    "@algolia/transporter" "4.20.0"
+    "@shikijs/primitive" "4.4.1"
+    "@shikijs/types" "4.4.1"
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.5"
+    hast-util-to-html "^9.0.5"
 
-"@algolia/client-search@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.20.0.tgz#3bcce817ca6caedc835e0eaf6f580e02ee7c3e15"
-  integrity sha512-zgwqnMvhWLdpzKTpd3sGmMlr4c+iS7eyyLGiaO51zDZWGMkpgoNVmltkzdBwxOVXz0RsFMznIxB9zuarUv4TZg==
+"@shikijs/engine-javascript@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/engine-javascript/-/engine-javascript-4.4.1.tgz#55c3c80f9b4bbf15d3a043bcdd311213ab025035"
+  integrity sha512-6U4lJBh8LTvIkEVqRHv/rr3ruwtO6IweFQt1ME1ntHJMGHS+6N86vfYGO1o8c/DtOCTia2lfhdQBtBrps1sDfQ==
   dependencies:
-    "@algolia/client-common" "4.20.0"
-    "@algolia/requester-common" "4.20.0"
-    "@algolia/transporter" "4.20.0"
+    "@shikijs/types" "4.4.1"
+    "@shikijs/vscode-textmate" "^10.0.2"
+    oniguruma-to-es "^4.3.6"
 
-"@algolia/logger-common@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.20.0.tgz#f148ddf67e5d733a06213bebf7117cb8a651ab36"
-  integrity sha512-xouigCMB5WJYEwvoWW5XDv7Z9f0A8VoXJc3VKwlHJw/je+3p2RcDXfksLI4G4lIVncFUYMZx30tP/rsdlvvzHQ==
-
-"@algolia/logger-console@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/logger-console/-/logger-console-4.20.0.tgz#ac443d27c4e94357f3063e675039cef0aa2de0a7"
-  integrity sha512-THlIGG1g/FS63z0StQqDhT6bprUczBI8wnLT3JWvfAQDZX5P6fCg7dG+pIrUBpDIHGszgkqYEqECaKKsdNKOUA==
+"@shikijs/engine-oniguruma@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.1.tgz#154d0956afefeb190ff15e70461de94d6dc7acde"
+  integrity sha512-p23RugMKss0r5DAtRJW1yAXUDl60JvhQYV20yuxei//26JyDSJefV3umyWzzwep2weblMnJGDYahuti6XkcMgA==
   dependencies:
-    "@algolia/logger-common" "4.20.0"
+    "@shikijs/types" "4.4.1"
+    "@shikijs/vscode-textmate" "^10.0.2"
 
-"@algolia/requester-browser-xhr@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.20.0.tgz#db16d0bdef018b93b51681d3f1e134aca4f64814"
-  integrity sha512-HbzoSjcjuUmYOkcHECkVTwAelmvTlgs48N6Owt4FnTOQdwn0b8pdht9eMgishvk8+F8bal354nhx/xOoTfwiAw==
+"@shikijs/langs@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/langs/-/langs-4.4.1.tgz#be81163be845499c8497e25430b0ee344f2c0a06"
+  integrity sha512-xb2kCMloBCIraIy2fS5MW0t/BxVY3q2nDyQKBoeSeq6KNrQbShHetCFlw2n35fGIJ6t3+hXDLQogP5ir9O9bvA==
   dependencies:
-    "@algolia/requester-common" "4.20.0"
+    "@shikijs/types" "4.4.1"
 
-"@algolia/requester-common@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.20.0.tgz#65694b2263a8712b4360fef18680528ffd435b5c"
-  integrity sha512-9h6ye6RY/BkfmeJp7Z8gyyeMrmmWsMOCRBXQDs4mZKKsyVlfIVICpcSibbeYcuUdurLhIlrOUkH3rQEgZzonng==
-
-"@algolia/requester-node-http@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-4.20.0.tgz#b52b182b52b0b16dec4070832267d484a6b1d5bb"
-  integrity sha512-ocJ66L60ABSSTRFnCHIEZpNHv6qTxsBwJEPfYaSBsLQodm0F9ptvalFkHMpvj5DfE22oZrcrLbOYM2bdPJRHng==
+"@shikijs/primitive@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/primitive/-/primitive-4.4.1.tgz#a2e9dcd541c2468d05c942468a3aabde361aee48"
+  integrity sha512-ko2OfDoG89YuQ7xL5LtcQiWKb7NIv1Ephb7g48TVU198OzAMLC8lXVEwaJGHK4sUMYrfAGJDqYmNLOLiW/Kz8w==
   dependencies:
-    "@algolia/requester-common" "4.20.0"
+    "@shikijs/types" "4.4.1"
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.5"
 
-"@algolia/transporter@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@algolia/transporter/-/transporter-4.20.0.tgz#7e5b24333d7cc9a926b2f6a249f87c2889b944a9"
-  integrity sha512-Lsii1pGWOAISbzeyuf+r/GPhvHMPHSPrTDWNcIzOE1SG1inlJHICaVe2ikuoRjcpgxZNU54Jl+if15SUCsaTUg==
+"@shikijs/themes@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/themes/-/themes-4.4.1.tgz#6badf17ce39c11da5d49d6cd61de6463bf140a3a"
+  integrity sha512-wudOaoFro+/Zl9gQv2W1Ur5XlVduqvTuYLI483Xi0wgc1A+cy1hfB2r6ac6ufBgF+ID7KJEW7L41MHrzQ4wH+w==
   dependencies:
-    "@algolia/cache-common" "4.20.0"
-    "@algolia/logger-common" "4.20.0"
-    "@algolia/requester-common" "4.20.0"
+    "@shikijs/types" "4.4.1"
 
-"@babel/parser@^7.20.15", "@babel/parser@^7.21.3":
-  version "7.23.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.0.tgz#da950e622420bf96ca0d0f2909cdddac3acd8719"
-  integrity sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==
-
-"@docsearch/css@3.5.2", "@docsearch/css@^3.5.2":
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-3.5.2.tgz#610f47b48814ca94041df969d9fcc47b91fc5aac"
-  integrity sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==
-
-"@docsearch/js@^3.5.2":
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/@docsearch/js/-/js-3.5.2.tgz#a11cb2e7e62890e9e940283fed6972ecf632629d"
-  integrity sha512-p1YFTCDflk8ieHgFJYfmyHBki1D61+U9idwrLh+GQQMrBSP3DLGKpy0XUJtPjAOPltcVbqsTjiPFfH7JImjUNg==
+"@shikijs/transformers@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/transformers/-/transformers-4.4.1.tgz#4c77e60d062c1fe08363c6671fc96f571a40a708"
+  integrity sha512-Sb9Eehas+5EhClpFgNuklwY3aWf354FLaKRCiAWmjdNbHAjoQUpv6WmSj+N19eTXO6GLIWh1dIOH9dxyauhVWw==
   dependencies:
-    "@docsearch/react" "3.5.2"
-    preact "^10.0.0"
+    "@shikijs/core" "4.4.1"
+    "@shikijs/types" "4.4.1"
 
-"@docsearch/react@3.5.2":
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/@docsearch/react/-/react-3.5.2.tgz#2e6bbee00eb67333b64906352734da6aef1232b9"
-  integrity sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==
+"@shikijs/types@4.4.1", "@shikijs/types@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/types/-/types-4.4.1.tgz#71322c24827b857a441ebe80345db3baedb68a4e"
+  integrity sha512-GOwCLQDHM5EjGUWNPrhzJbr6JP8V/Dx/CDVkWvbZ1Avw5JFnNUckrgbLmE07qtg4WlW7Q7QFndhjIkeU9XMPvw==
   dependencies:
-    "@algolia/autocomplete-core" "1.9.3"
-    "@algolia/autocomplete-preset-algolia" "1.9.3"
-    "@docsearch/css" "3.5.2"
-    algoliasearch "^4.19.1"
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.5"
 
-"@esbuild/android-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz#984b4f9c8d0377443cc2dfcef266d02244593622"
-  integrity sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==
+"@shikijs/vscode-textmate@^10.0.2":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz#a90ab31d0cc1dfb54c66a69e515bf624fa7b2224"
+  integrity sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==
 
-"@esbuild/android-arm@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.18.20.tgz#fedb265bc3a589c84cc11f810804f234947c3682"
-  integrity sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==
+"@tybys/wasm-util@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.3.tgz#015cba9e9dd47ce14d03d2a8c5d547bfb169665d"
+  integrity sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==
+  dependencies:
+    tslib "^2.4.0"
 
-"@esbuild/android-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.18.20.tgz#35cf419c4cfc8babe8893d296cd990e9e9f756f2"
-  integrity sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==
+"@types/hast@^3.0.0", "@types/hast@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.5.tgz#48020de4c0e63492f4ca9db42068c108f68b7f8f"
+  integrity sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==
+  dependencies:
+    "@types/unist" "*"
 
-"@esbuild/darwin-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz#08172cbeccf95fbc383399a7f39cfbddaeb0d7c1"
-  integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
+"@types/linkify-it@^5":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-5.0.0.tgz#21413001973106cda1c3a9b91eedd4ccd5469d76"
+  integrity sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==
 
-"@esbuild/darwin-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz#d70d5790d8bf475556b67d0f8b7c5bdff053d85d"
-  integrity sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==
+"@types/markdown-it@^14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-14.1.2.tgz#57f2532a0800067d9b934f3521429a2e8bfb4c61"
+  integrity sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==
+  dependencies:
+    "@types/linkify-it" "^5"
+    "@types/mdurl" "^2"
 
-"@esbuild/freebsd-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz#98755cd12707f93f210e2494d6a4b51b96977f54"
-  integrity sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==
+"@types/mdast@^4.0.0":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-4.0.4.tgz#7ccf72edd2f1aa7dd3437e180c64373585804dd6"
+  integrity sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==
+  dependencies:
+    "@types/unist" "*"
 
-"@esbuild/freebsd-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz#c1eb2bff03915f87c29cece4c1a7fa1f423b066e"
-  integrity sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==
+"@types/mdurl@^2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-2.0.0.tgz#d43878b5b20222682163ae6f897b20447233bdfd"
+  integrity sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==
 
-"@esbuild/linux-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz#bad4238bd8f4fc25b5a021280c770ab5fc3a02a0"
-  integrity sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==
-
-"@esbuild/linux-arm@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz#3e617c61f33508a27150ee417543c8ab5acc73b0"
-  integrity sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==
-
-"@esbuild/linux-ia32@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz#699391cccba9aee6019b7f9892eb99219f1570a7"
-  integrity sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==
-
-"@esbuild/linux-loong64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz#e6fccb7aac178dd2ffb9860465ac89d7f23b977d"
-  integrity sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==
-
-"@esbuild/linux-mips64el@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz#eeff3a937de9c2310de30622a957ad1bd9183231"
-  integrity sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==
-
-"@esbuild/linux-ppc64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz#2f7156bde20b01527993e6881435ad79ba9599fb"
-  integrity sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==
-
-"@esbuild/linux-riscv64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz#6628389f210123d8b4743045af8caa7d4ddfc7a6"
-  integrity sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==
-
-"@esbuild/linux-s390x@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz#255e81fb289b101026131858ab99fba63dcf0071"
-  integrity sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==
-
-"@esbuild/linux-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz#c7690b3417af318a9b6f96df3031a8865176d338"
-  integrity sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==
-
-"@esbuild/netbsd-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz#30e8cd8a3dded63975e2df2438ca109601ebe0d1"
-  integrity sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==
-
-"@esbuild/openbsd-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz#7812af31b205055874c8082ea9cf9ab0da6217ae"
-  integrity sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==
-
-"@esbuild/sunos-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz#d5c275c3b4e73c9b0ecd38d1ca62c020f887ab9d"
-  integrity sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==
-
-"@esbuild/win32-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz#73bc7f5a9f8a77805f357fab97f290d0e4820ac9"
-  integrity sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==
-
-"@esbuild/win32-ia32@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz#ec93cbf0ef1085cc12e71e0d661d20569ff42102"
-  integrity sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==
-
-"@esbuild/win32-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
-  integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
-
-"@jridgewell/sourcemap-codec@^1.4.15":
-  version "1.4.15"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
-  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
-
-"@types/linkify-it@*":
+"@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.3.tgz#15a0712296c5041733c79efe233ba17ae5a7587b"
-  integrity sha512-pTjcqY9E4nOI55Wgpz7eiI8+LzdYnw3qxXCfHyBDdPbYvbyLgWLJGh8EdPvqawwMK1Uo1794AUkkR38Fr0g+2g==
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
+  integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
 
-"@types/markdown-it@^13.0.2":
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-13.0.2.tgz#1557e77789fc86e93fd4b8f0f8f8535ec97a8518"
-  integrity sha512-Tla7hH9oeXHOlJyBFdoqV61xWE9FZf/y2g+gFVwQ2vE1/eBzjUno5JCd3Hdb5oATve5OF6xNjZ/4VIZhVVx+hA==
+"@types/web-bluetooth@^0.0.21":
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz#525433c784aed9b457aaa0ee3d92aeb71f346b63"
+  integrity sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==
+
+"@ungap/structured-clone@^1.0.0":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.3.tgz#094041e1a4cb1987f038335421281ac8be390bcc"
+  integrity sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==
+
+"@vitejs/plugin-vue@^6.0.8":
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-6.0.8.tgz#1809d090b7c93b8f4ae83d3e7536655cbbb1c793"
+  integrity sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==
   dependencies:
-    "@types/linkify-it" "*"
-    "@types/mdurl" "*"
+    "@rolldown/pluginutils" "^1.0.1"
 
-"@types/mdurl@*":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.3.tgz#d0aefccdd1a96f4bec76047d6b314601f0b0f3de"
-  integrity sha512-T5k6kTXak79gwmIOaDF2UUQXFbnBE0zBUzF20pz7wDYu0RQMzWg+Ml/Pz50214NsFHBITkoi5VtdjFZnJ2ijjA==
-
-"@types/web-bluetooth@^0.0.18":
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.18.tgz#74bd1c8fd3a2058cb6fc76b188fcded50a83d866"
-  integrity sha512-v/ZHEj9xh82usl8LMR3GarzFY1IrbXJw5L4QfQhokjRV91q+SelFqxQWSep1ucXEZ22+dSTwLFkXeur25sPIbw==
-
-"@vue/compiler-core@3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.3.4.tgz#7fbf591c1c19e1acd28ffd284526e98b4f581128"
-  integrity sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==
+"@vue/compiler-core@3.5.40":
+  version "3.5.40"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.5.40.tgz#a3e9e280ef3dccb6de4c7707ba50d7e10fd598a5"
+  integrity sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==
   dependencies:
-    "@babel/parser" "^7.21.3"
-    "@vue/shared" "3.3.4"
+    "@babel/parser" "^7.29.7"
+    "@vue/shared" "3.5.40"
+    entities "^7.0.1"
     estree-walker "^2.0.2"
-    source-map-js "^1.0.2"
+    source-map-js "^1.2.1"
 
-"@vue/compiler-dom@3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz#f56e09b5f4d7dc350f981784de9713d823341151"
-  integrity sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==
+"@vue/compiler-dom@3.5.40":
+  version "3.5.40"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz#ac0579d4dc257bf5e10ce324a7ce0a7f9fc5c338"
+  integrity sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==
   dependencies:
-    "@vue/compiler-core" "3.3.4"
-    "@vue/shared" "3.3.4"
+    "@vue/compiler-core" "3.5.40"
+    "@vue/shared" "3.5.40"
 
-"@vue/compiler-sfc@3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz#b19d942c71938893535b46226d602720593001df"
-  integrity sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==
+"@vue/compiler-sfc@3.5.40":
+  version "3.5.40"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz#22252b2e5a58a6b6a4f71565cfa91271bddbe782"
+  integrity sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==
   dependencies:
-    "@babel/parser" "^7.20.15"
-    "@vue/compiler-core" "3.3.4"
-    "@vue/compiler-dom" "3.3.4"
-    "@vue/compiler-ssr" "3.3.4"
-    "@vue/reactivity-transform" "3.3.4"
-    "@vue/shared" "3.3.4"
+    "@babel/parser" "^7.29.7"
+    "@vue/compiler-core" "3.5.40"
+    "@vue/compiler-dom" "3.5.40"
+    "@vue/compiler-ssr" "3.5.40"
+    "@vue/shared" "3.5.40"
     estree-walker "^2.0.2"
-    magic-string "^0.30.0"
-    postcss "^8.1.10"
-    source-map-js "^1.0.2"
+    magic-string "^0.30.21"
+    postcss "^8.5.19"
+    source-map-js "^1.2.1"
 
-"@vue/compiler-ssr@3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz#9d1379abffa4f2b0cd844174ceec4a9721138777"
-  integrity sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==
+"@vue/compiler-ssr@3.5.40":
+  version "3.5.40"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.5.40.tgz#c8c80efd22f5d85ea775d6ead787a108dc86cd58"
+  integrity sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==
   dependencies:
-    "@vue/compiler-dom" "3.3.4"
-    "@vue/shared" "3.3.4"
+    "@vue/compiler-dom" "3.5.40"
+    "@vue/shared" "3.5.40"
 
-"@vue/devtools-api@^6.5.1":
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.5.1.tgz#7f71f31e40973eeee65b9a64382b13593fdbd697"
-  integrity sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA==
-
-"@vue/reactivity-transform@3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz#52908476e34d6a65c6c21cd2722d41ed8ae51929"
-  integrity sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==
+"@vue/devtools-api@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-8.2.1.tgz#9d95de2b908aa80b9957d737ddca51790e70c3b5"
+  integrity sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==
   dependencies:
-    "@babel/parser" "^7.20.15"
-    "@vue/compiler-core" "3.3.4"
-    "@vue/shared" "3.3.4"
-    estree-walker "^2.0.2"
-    magic-string "^0.30.0"
+    "@vue/devtools-kit" "^8.2.1"
 
-"@vue/reactivity@3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.3.4.tgz#a27a29c6cd17faba5a0e99fbb86ee951653e2253"
-  integrity sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==
+"@vue/devtools-kit@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-kit/-/devtools-kit-8.2.1.tgz#ad45babb12c51931d32d1b67ffaebc251f550ce9"
+  integrity sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==
   dependencies:
-    "@vue/shared" "3.3.4"
+    "@vue/devtools-shared" "^8.2.1"
+    birpc "^2.6.1"
+    hookable "^5.5.3"
+    perfect-debounce "^2.0.0"
 
-"@vue/runtime-core@3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.3.4.tgz#4bb33872bbb583721b340f3088888394195967d1"
-  integrity sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==
+"@vue/devtools-shared@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-shared/-/devtools-shared-8.2.1.tgz#26524e9e12fd205bcd5477cf3b5e9a17b876aeac"
+  integrity sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==
+
+"@vue/reactivity@3.5.40":
+  version "3.5.40"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.5.40.tgz#91379172a9e9daba6737c6931382127976c830ba"
+  integrity sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==
   dependencies:
-    "@vue/reactivity" "3.3.4"
-    "@vue/shared" "3.3.4"
+    "@vue/shared" "3.5.40"
 
-"@vue/runtime-dom@3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz#992f2579d0ed6ce961f47bbe9bfe4b6791251566"
-  integrity sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==
+"@vue/runtime-core@3.5.40":
+  version "3.5.40"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.5.40.tgz#abdd20bc19244154eac7bcaf5ec68e95d5d8b1bc"
+  integrity sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==
   dependencies:
-    "@vue/runtime-core" "3.3.4"
-    "@vue/shared" "3.3.4"
-    csstype "^3.1.1"
+    "@vue/reactivity" "3.5.40"
+    "@vue/shared" "3.5.40"
 
-"@vue/server-renderer@3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.3.4.tgz#ea46594b795d1536f29bc592dd0f6655f7ea4c4c"
-  integrity sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==
+"@vue/runtime-dom@3.5.40":
+  version "3.5.40"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.5.40.tgz#ed72f072c31e7868c0c59ad5883138cd7e0d88a5"
+  integrity sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==
   dependencies:
-    "@vue/compiler-ssr" "3.3.4"
-    "@vue/shared" "3.3.4"
+    "@vue/reactivity" "3.5.40"
+    "@vue/runtime-core" "3.5.40"
+    "@vue/shared" "3.5.40"
+    csstype "^3.2.3"
 
-"@vue/shared@3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.3.4.tgz#06e83c5027f464eef861c329be81454bc8b70780"
-  integrity sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==
-
-"@vueuse/core@10.5.0", "@vueuse/core@^10.5.0":
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-10.5.0.tgz#04d1e6d26592bb997bb755a4830ea7583c3e8612"
-  integrity sha512-z/tI2eSvxwLRjOhDm0h/SXAjNm8N5ld6/SC/JQs6o6kpJ6Ya50LnEL8g5hoYu005i28L0zqB5L5yAl8Jl26K3A==
+"@vue/server-renderer@3.5.40":
+  version "3.5.40"
+  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.5.40.tgz#94c7ccd0bf14ec3b19047e56b86f798be6736fda"
+  integrity sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==
   dependencies:
-    "@types/web-bluetooth" "^0.0.18"
-    "@vueuse/metadata" "10.5.0"
-    "@vueuse/shared" "10.5.0"
-    vue-demi ">=0.14.6"
+    "@vue/compiler-ssr" "3.5.40"
+    "@vue/runtime-dom" "3.5.40"
+    "@vue/shared" "3.5.40"
 
-"@vueuse/integrations@^10.5.0":
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/@vueuse/integrations/-/integrations-10.5.0.tgz#38f00bd5a1cd0160645f0c75efd5d9579061e3d6"
-  integrity sha512-fm5sXLCK0Ww3rRnzqnCQRmfjDURaI4xMsx+T+cec0ngQqHx/JgUtm8G0vRjwtonIeTBsH1Q8L3SucE+7K7upJQ==
+"@vue/shared@3.5.40", "@vue/shared@^3.5.40":
+  version "3.5.40"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.40.tgz#fc09d1871d66cd9b01959a597b41d7cb61f716a8"
+  integrity sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==
+
+"@vueuse/core@14.4.0", "@vueuse/core@^14.4.0":
+  version "14.4.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-14.4.0.tgz#a841da6b3c7d548bdeed5bf611e73f3de62d20fa"
+  integrity sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==
   dependencies:
-    "@vueuse/core" "10.5.0"
-    "@vueuse/shared" "10.5.0"
-    vue-demi ">=0.14.6"
+    "@types/web-bluetooth" "^0.0.21"
+    "@vueuse/metadata" "14.4.0"
+    "@vueuse/shared" "14.4.0"
 
-"@vueuse/metadata@10.5.0":
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-10.5.0.tgz#7501a88cf5cbf7a515a03f0b8bbe3cecf30cad11"
-  integrity sha512-fEbElR+MaIYyCkeM0SzWkdoMtOpIwO72x8WsZHRE7IggiOlILttqttM69AS13nrDxosnDBYdyy3C5mR1LCxHsw==
-
-"@vueuse/shared@10.5.0":
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-10.5.0.tgz#b3ac8c190a5dae41db5e1b60fe304a9b4247393c"
-  integrity sha512-18iyxbbHYLst9MqU1X1QNdMHIjks6wC7XTVf0KNOv5es/Ms6gjVFCAAWTVP2JStuGqydg3DT+ExpFORUEi9yhg==
+"@vueuse/integrations@^14.4.0":
+  version "14.4.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/integrations/-/integrations-14.4.0.tgz#32b6854e3d27bfe2cfee966a997f709022a7e3be"
+  integrity sha512-oJz9qTgczvA7L1nXQFRU7h8tQbOCoiceqvMMhT9XYMyOGTqLJ2rEa09PON+nD2t48sZUfeOmg4eaWJXV4sZb/w==
   dependencies:
-    vue-demi ">=0.14.6"
+    "@vueuse/core" "14.4.0"
+    "@vueuse/shared" "14.4.0"
 
-algoliasearch@^4.19.1:
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.20.0.tgz#700c2cb66e14f8a288460036c7b2a554d0d93cf4"
-  integrity sha512-y+UHEjnOItoNy0bYO+WWmLWBlPwDjKHW6mNHrPi0NkuhpQOOEbrkwQH/wgKFDLh7qlKjzoKeiRtlpewDPDG23g==
+"@vueuse/metadata@14.4.0":
+  version "14.4.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-14.4.0.tgz#a2508499b803bac14775a9c9b852b8738fc16f98"
+  integrity sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==
+
+"@vueuse/shared@14.4.0":
+  version "14.4.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-14.4.0.tgz#4e89813c7859d153d48c03d74bff78739f96723b"
+  integrity sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==
+
+birpc@^2.6.1:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/birpc/-/birpc-2.9.0.tgz#b59550897e4cd96a223e2a6c1475b572236ed145"
+  integrity sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==
+
+ccount@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
+  integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+
+character-entities-html4@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-2.1.0.tgz#1f1adb940c971a4b22ba39ddca6b618dc6e56b2b"
+  integrity sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==
+
+character-entities-legacy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
+  integrity sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
+
+comma-separated-tokens@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
+  integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
+
+csstype@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
+  integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
+
+dequal@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+detect-libc@^2.0.3:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
+
+devlop@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/devlop/-/devlop-1.1.0.tgz#4db7c2ca4dc6e0e834c30be70c94bbc976dc7018"
+  integrity sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
   dependencies:
-    "@algolia/cache-browser-local-storage" "4.20.0"
-    "@algolia/cache-common" "4.20.0"
-    "@algolia/cache-in-memory" "4.20.0"
-    "@algolia/client-account" "4.20.0"
-    "@algolia/client-analytics" "4.20.0"
-    "@algolia/client-common" "4.20.0"
-    "@algolia/client-personalization" "4.20.0"
-    "@algolia/client-search" "4.20.0"
-    "@algolia/logger-common" "4.20.0"
-    "@algolia/logger-console" "4.20.0"
-    "@algolia/requester-browser-xhr" "4.20.0"
-    "@algolia/requester-common" "4.20.0"
-    "@algolia/requester-node-http" "4.20.0"
-    "@algolia/transporter" "4.20.0"
+    dequal "^2.0.0"
 
-ansi-sequence-parser@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz#e0aa1cdcbc8f8bb0b5bca625aac41f5f056973cf"
-  integrity sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==
-
-csstype@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
-  integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
-
-esbuild@^0.18.10:
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.18.20.tgz#4709f5a34801b43b799ab7d6d82f7284a9b7a7a6"
-  integrity sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==
-  optionalDependencies:
-    "@esbuild/android-arm" "0.18.20"
-    "@esbuild/android-arm64" "0.18.20"
-    "@esbuild/android-x64" "0.18.20"
-    "@esbuild/darwin-arm64" "0.18.20"
-    "@esbuild/darwin-x64" "0.18.20"
-    "@esbuild/freebsd-arm64" "0.18.20"
-    "@esbuild/freebsd-x64" "0.18.20"
-    "@esbuild/linux-arm" "0.18.20"
-    "@esbuild/linux-arm64" "0.18.20"
-    "@esbuild/linux-ia32" "0.18.20"
-    "@esbuild/linux-loong64" "0.18.20"
-    "@esbuild/linux-mips64el" "0.18.20"
-    "@esbuild/linux-ppc64" "0.18.20"
-    "@esbuild/linux-riscv64" "0.18.20"
-    "@esbuild/linux-s390x" "0.18.20"
-    "@esbuild/linux-x64" "0.18.20"
-    "@esbuild/netbsd-x64" "0.18.20"
-    "@esbuild/openbsd-x64" "0.18.20"
-    "@esbuild/sunos-x64" "0.18.20"
-    "@esbuild/win32-arm64" "0.18.20"
-    "@esbuild/win32-ia32" "0.18.20"
-    "@esbuild/win32-x64" "0.18.20"
+entities@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
+  integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
 
 estree-walker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
-focus-trap@^7.5.3:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.5.4.tgz#6c4e342fe1dae6add9c2aa332a6e7a0bbd495ba2"
-  integrity sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==
-  dependencies:
-    tabbable "^6.2.0"
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
-fsevents@~2.3.2:
+focus-trap@^8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-8.2.2.tgz#6e8a203f2228ca8b5eb95465433e69a5d5e48387"
+  integrity sha512-qV0g8hRYBqgACcFOH3f9wXc4zPKhr/0z9RI2a6ZijZ72EeBi4g8oBy8zAWuUR1TsMpOzwpUMFvjdasrC41Joug==
+  dependencies:
+    tabbable "^6.5.0"
+
+fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-jsonc-parser@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
-  integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
-
-magic-string@^0.30.0:
-  version "0.30.5"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.5.tgz#1994d980bd1c8835dc6e78db7cbd4ae4f24746f9"
-  integrity sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==
+hast-util-to-html@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz#ccc673a55bb8e85775b08ac28380f72d47167005"
+  integrity sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==
   dependencies:
-    "@jridgewell/sourcemap-codec" "^1.4.15"
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    ccount "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-whitespace "^3.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+    stringify-entities "^4.0.0"
+    zwitch "^2.0.4"
+
+hast-util-whitespace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
+  integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hookable@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/hookable/-/hookable-5.5.3.tgz#6cfc358984a1ef991e2518cb9ed4a778bbd3215d"
+  integrity sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==
+
+html-void-elements@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
+  integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
+
+lightningcss-android-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz#9a6841f88ae50fc83502903892b41af41bc2b907"
+  integrity sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==
+
+lightningcss-darwin-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz#c0f2c31c0bfd19fa4dd3f18e957a1f1a152097d6"
+  integrity sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==
+
+lightningcss-darwin-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz#cb0705965acb538c6683949ce6925fb3cdf7c361"
+  integrity sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==
+
+lightningcss-freebsd-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz#763538828b26bab2680dadafcc84ee78b0eb502b"
+  integrity sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==
+
+lightningcss-linux-arm-gnueabihf@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz#6862e3176a331aedbdec1ed352b4d7d0dd0784de"
+  integrity sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==
+
+lightningcss-linux-arm64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz#c6a3a2ed15141daf6bdc2628930f8e39bdf473aa"
+  integrity sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==
+
+lightningcss-linux-arm64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz#7fa1334971fc82845f9827df6ef8a0b20914bac6"
+  integrity sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==
+
+lightningcss-linux-x64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz#8b927862ea8c2bbc6831a46509244b50d9936e55"
+  integrity sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==
+
+lightningcss-linux-x64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz#0c525bb077dfd94404c059cfe42dad797e96aeaf"
+  integrity sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==
+
+lightningcss-win32-arm64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz#850ee1103dac989cfab50e3ac22d1a69e394e63d"
+  integrity sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==
+
+lightningcss-win32-x64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz#e343ae152eed3609dc6e11949d1a3bf39a1c946f"
+  integrity sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==
+
+lightningcss@^1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.33.0.tgz#c08867d71a79385c6e190214fd72fef3e5f95f0b"
+  integrity sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==
+  dependencies:
+    detect-libc "^2.0.3"
+  optionalDependencies:
+    lightningcss-android-arm64 "1.33.0"
+    lightningcss-darwin-arm64 "1.33.0"
+    lightningcss-darwin-x64 "1.33.0"
+    lightningcss-freebsd-x64 "1.33.0"
+    lightningcss-linux-arm-gnueabihf "1.33.0"
+    lightningcss-linux-arm64-gnu "1.33.0"
+    lightningcss-linux-arm64-musl "1.33.0"
+    lightningcss-linux-x64-gnu "1.33.0"
+    lightningcss-linux-x64-musl "1.33.0"
+    lightningcss-win32-arm64-msvc "1.33.0"
+    lightningcss-win32-x64-msvc "1.33.0"
+
+magic-string@^0.30.21:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 mark.js@8.11.1:
   version "8.11.1"
   resolved "https://registry.yarnpkg.com/mark.js/-/mark.js-8.11.1.tgz#180f1f9ebef8b0e638e4166ad52db879beb2ffc5"
   integrity sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==
 
-minisearch@^6.1.0:
+mdast-util-to-hast@^13.0.0:
+  version "13.2.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz#d7ff84ca499a57e2c060ae67548ad950e689a053"
+  integrity sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    devlop "^1.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    trim-lines "^3.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+
+micromark-util-character@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-2.1.1.tgz#2f987831a40d4c510ac261e89852c4e9703ccda6"
+  integrity sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-encode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz#0d51d1c095551cfaac368326963cf55f15f540b8"
+  integrity sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==
+
+micromark-util-sanitize-uri@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz#ab89789b818a58752b73d6b55238621b7faa8fd7"
+  integrity sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-symbol@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz#e5da494e8eb2b071a0d08fb34f6cefec6c0a19b8"
+  integrity sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==
+
+micromark-util-types@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-2.0.2.tgz#f00225f5f5a0ebc3254f96c36b6605c4b393908e"
+  integrity sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==
+
+minisearch@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/minisearch/-/minisearch-7.2.0.tgz#3dc30e41e9464b3836553b6d969b656614f8f359"
+  integrity sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==
+
+nanoid@^3.3.16:
+  version "3.3.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
+  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+
+oniguruma-parser@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz#e27ca446f7fcf0969662a3ab9b4f43176d62b139"
+  integrity sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==
+
+oniguruma-to-es@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz#43e640280241b0d687a314e7a641d476407a1c4d"
+  integrity sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==
+  dependencies:
+    oniguruma-parser "^0.12.2"
+    regex "^6.1.0"
+    regex-recursion "^6.0.2"
+
+perfect-debounce@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/perfect-debounce/-/perfect-debounce-2.1.0.tgz#e7078e38f231cb191855c3136a4423aef725d261"
+  integrity sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==
+
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
+picomatch@^4.0.4, picomatch@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
+  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
+
+postcss@^8.5.19, postcss@^8.5.23:
+  version "8.5.25"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.25.tgz#5012a598eaaa897f21bbe8553be3cb7bd2bd78cb"
+  integrity sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==
+  dependencies:
+    nanoid "^3.3.16"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+property-information@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-7.2.0.tgz#0809b34264e995c0bfcd3227028a1e35210af80a"
+  integrity sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==
+
+regex-recursion@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/regex-recursion/-/regex-recursion-6.0.2.tgz#a0b1977a74c87f073377b938dbedfab2ea582b33"
+  integrity sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==
+  dependencies:
+    regex-utilities "^2.3.0"
+
+regex-utilities@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/regex-utilities/-/regex-utilities-2.3.0.tgz#87163512a15dce2908cf079c8960d5158ff43280"
+  integrity sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==
+
+regex@^6.1.0:
   version "6.1.0"
-  resolved "https://registry.yarnpkg.com/minisearch/-/minisearch-6.1.0.tgz#6e74e743dbd0e88fa5ca52fef2391e0aa7055252"
-  integrity sha512-PNxA/X8pWk+TiqPbsoIYH0GQ5Di7m6326/lwU/S4mlo4wGQddIcf/V//1f9TB0V4j59b57b+HZxt8h3iMROGvg==
-
-nanoid@^3.3.6:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
-  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
-
-picocolors@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
-  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
-
-postcss@^8.1.10, postcss@^8.4.27:
-  version "8.4.31"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
-  integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
+  resolved "https://registry.yarnpkg.com/regex/-/regex-6.1.0.tgz#d7ce98f8ee32da7497c13f6601fca2bc4a6a7803"
+  integrity sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==
   dependencies:
-    nanoid "^3.3.6"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
+    regex-utilities "^2.3.0"
 
-preact@^10.0.0:
-  version "10.18.1"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.18.1.tgz#3b84bb305f0b05f4ad5784b981d15fcec4e105da"
-  integrity sha512-mKUD7RRkQQM6s7Rkmi7IFkoEHjuFqRQUaXamO61E6Nn7vqF/bo7EZCmSyrUnp2UWHw0O7XjZ2eeXis+m7tf4lg==
-
-rollup@^3.27.1:
-  version "3.29.4"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.4.tgz#4d70c0f9834146df8705bfb69a9a19c9e1109981"
-  integrity sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==
+rolldown@~1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.2.1.tgz#644204bde3da11e0eaa8d74994be25b90fcf4d44"
+  integrity sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==
+  dependencies:
+    "@oxc-project/types" "=0.142.0"
+    "@rolldown/pluginutils" "^1.0.0"
   optionalDependencies:
-    fsevents "~2.3.2"
+    "@rolldown/binding-android-arm64" "1.2.1"
+    "@rolldown/binding-darwin-arm64" "1.2.1"
+    "@rolldown/binding-darwin-x64" "1.2.1"
+    "@rolldown/binding-freebsd-x64" "1.2.1"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.2.1"
+    "@rolldown/binding-linux-arm64-gnu" "1.2.1"
+    "@rolldown/binding-linux-arm64-musl" "1.2.1"
+    "@rolldown/binding-linux-ppc64-gnu" "1.2.1"
+    "@rolldown/binding-linux-s390x-gnu" "1.2.1"
+    "@rolldown/binding-linux-x64-gnu" "1.2.1"
+    "@rolldown/binding-linux-x64-musl" "1.2.1"
+    "@rolldown/binding-openharmony-arm64" "1.2.1"
+    "@rolldown/binding-wasm32-wasi" "1.2.1"
+    "@rolldown/binding-win32-arm64-msvc" "1.2.1"
+    "@rolldown/binding-win32-x64-msvc" "1.2.1"
 
-shiki@^0.14.5:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.14.5.tgz#375dd214e57eccb04f0daf35a32aa615861deb93"
-  integrity sha512-1gCAYOcmCFONmErGTrS1fjzJLA7MGZmKzrBNX7apqSwhyITJg2O102uFzXUeBxNnEkDA9vHIKLyeKq0V083vIw==
+shiki@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-4.4.1.tgz#97b1646edc7168adec70b65511cd48f0dfcefd2a"
+  integrity sha512-rFP+iYKzjLEIqiMiKANhARqiAbk4deDhWnBtnUO/K0D0dPxMGDH4N0FVfBY/VeI+lPrV4wNGCHQZp7EOr7NNBw==
   dependencies:
-    ansi-sequence-parser "^1.1.0"
-    jsonc-parser "^3.2.0"
-    vscode-oniguruma "^1.7.0"
-    vscode-textmate "^8.0.0"
+    "@shikijs/core" "4.4.1"
+    "@shikijs/engine-javascript" "4.4.1"
+    "@shikijs/engine-oniguruma" "4.4.1"
+    "@shikijs/langs" "4.4.1"
+    "@shikijs/themes" "4.4.1"
+    "@shikijs/types" "4.4.1"
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.5"
 
-source-map-js@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
-  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
-tabbable@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
-  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
+space-separated-tokens@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz#1ecd9d2350a3844572c3f4a312bceb018348859f"
+  integrity sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
 
-vite@^4.4.11:
-  version "4.4.11"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.4.11.tgz#babdb055b08c69cfc4c468072a2e6c9ca62102b0"
-  integrity sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==
+stringify-entities@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-4.0.4.tgz#b3b79ef5f277cc4ac73caeb0236c5ba939b3a4f3"
+  integrity sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==
   dependencies:
-    esbuild "^0.18.10"
-    postcss "^8.4.27"
-    rollup "^3.27.1"
+    character-entities-html4 "^2.0.0"
+    character-entities-legacy "^3.0.0"
+
+tabbable@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.5.0.tgz#a65101385a4fd6cbd580b7546da0170f307b535d"
+  integrity sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==
+
+tinyglobby@^0.2.17:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
+
+trim-lines@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
+  integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
+
+tslib@^2.4.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+unist-util-is@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-6.0.1.tgz#d0a3f86f2dd0db7acd7d8c2478080b5c67f9c6a9"
+  integrity sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-position@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-5.0.0.tgz#678f20ab5ca1207a97d7ea8a388373c9cf896be4"
+  integrity sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-stringify-position@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz#449c6e21a880e0855bf5aabadeb3a740314abac2"
+  integrity sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-visit-parents@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz#777df7fb98652ce16b4b7cd999d0a1a40efa3a02"
+  integrity sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+
+unist-util-visit@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz#9a2a28b0aa76a15e0da70a08a5863a2f060e2468"
+  integrity sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
+
+vfile-message@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.3.tgz#87b44dddd7b70f0641c2e3ed0864ba73e2ea8df4"
+  integrity sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-stringify-position "^4.0.0"
+
+vfile@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-6.0.3.tgz#3652ab1c496531852bf55a6bac57af981ebc38ab"
+  integrity sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile-message "^4.0.0"
+
+vite@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.2.0.tgz#902fcd3dc0312f553c85b6cbc4625dcaca2d8df8"
+  integrity sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==
+  dependencies:
+    lightningcss "^1.33.0"
+    picomatch "^4.0.5"
+    postcss "^8.5.23"
+    rolldown "~1.2.0"
+    tinyglobby "^0.2.17"
   optionalDependencies:
-    fsevents "~2.3.2"
+    fsevents "~2.3.3"
 
-vitepress@^1.0.0-rc.21:
-  version "1.0.0-rc.21"
-  resolved "https://registry.yarnpkg.com/vitepress/-/vitepress-1.0.0-rc.21.tgz#fbe1a63db86a37729c554048e4df3c606ba0d803"
-  integrity sha512-eHX057NgAqmrj6FIqh7Sqsbk/kftrFMBUpCKjuQIZ+c+bYTbmzXsXrHSbT5b4WWy4vLx1993a+H3wIRy2dHi8g==
+vitepress@2.0.0-alpha.19:
+  version "2.0.0-alpha.19"
+  resolved "https://registry.yarnpkg.com/vitepress/-/vitepress-2.0.0-alpha.19.tgz#c5f1b1597e4199170e909f270849e25c2cadf033"
+  integrity sha512-WnBsb0Bwr43kXKyiis+lld/7ri3hnMbthS8N3hpFtjjwsdLO4IRmiAE08D7aud4q6oMDf9uwRowxzNqRFe/amw==
   dependencies:
-    "@docsearch/css" "^3.5.2"
-    "@docsearch/js" "^3.5.2"
-    "@types/markdown-it" "^13.0.2"
-    "@vue/devtools-api" "^6.5.1"
-    "@vueuse/core" "^10.5.0"
-    "@vueuse/integrations" "^10.5.0"
-    focus-trap "^7.5.3"
+    "@docsearch/css" "^4.7.0"
+    "@docsearch/js" "^4.7.0"
+    "@docsearch/sidepanel-js" "^4.7.0"
+    "@iconify-json/simple-icons" "^1.2.92"
+    "@shikijs/core" "^4.4.1"
+    "@shikijs/transformers" "^4.4.1"
+    "@shikijs/types" "^4.4.1"
+    "@types/markdown-it" "^14.1.2"
+    "@vitejs/plugin-vue" "^6.0.8"
+    "@vue/devtools-api" "^8.2.1"
+    "@vue/shared" "^3.5.40"
+    "@vueuse/core" "^14.4.0"
+    "@vueuse/integrations" "^14.4.0"
+    focus-trap "^8.2.2"
     mark.js "8.11.1"
-    minisearch "^6.1.0"
-    shiki "^0.14.5"
-    vite "^4.4.11"
-    vue "^3.3.4"
+    minisearch "^7.2.0"
+    shiki "^4.4.1"
+    vite "^8.2.0"
+    vue "^3.5.40"
 
-vscode-oniguruma@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz#439bfad8fe71abd7798338d1cd3dc53a8beea94b"
-  integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
-
-vscode-textmate@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz#2c7a3b1163ef0441097e0b5d6389cd5504b59e5d"
-  integrity sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==
-
-vue-demi@>=0.14.6:
-  version "0.14.6"
-  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.6.tgz#dc706582851dc1cdc17a0054f4fec2eb6df74c92"
-  integrity sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==
-
-vue@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.3.4.tgz#8ed945d3873667df1d0fcf3b2463ada028f88bd6"
-  integrity sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==
+vue@^3.5.40:
+  version "3.5.40"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.5.40.tgz#c4a9d4c62f98ea33aa811a75c3fbd476dc782184"
+  integrity sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==
   dependencies:
-    "@vue/compiler-dom" "3.3.4"
-    "@vue/compiler-sfc" "3.3.4"
-    "@vue/runtime-dom" "3.3.4"
-    "@vue/server-renderer" "3.3.4"
-    "@vue/shared" "3.3.4"
+    "@vue/compiler-dom" "3.5.40"
+    "@vue/compiler-sfc" "3.5.40"
+    "@vue/runtime-dom" "3.5.40"
+    "@vue/server-renderer" "3.5.40"
+    "@vue/shared" "3.5.40"
+
+zwitch@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
+  integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==


### PR DESCRIPTION
Brings the site in line with `python-stopwatch2` 2.0.0.

## Every literal output is now verified against the real package

The pages are full of example outputs that were written by hand. I installed
`python-stopwatch2==2.0.0` from PyPI and ran each one. Two were wrong:

- The `report()` example printed `total=1.0s, mean=0.2s, ... dev=0.1s`. With the
  default precision of 2 the real output is
  `total=1.00s, mean=0.20s, ... dev=0.14s`.
- Both `profile` examples ended with the final report printed twice. That
  duplication was a bug, fixed in 2.0.0, so the repeated line is gone.

## Documents what 2.0.0 added

- `Stopwatch(autostart=False)`, with the measured before/after: 0.5s of setup
  before the first `lap()` lands in that lap as `0.60s` without it, `0.10s`
  with it.
- `Statistics.stdev`.
- `profile` on `async def` — previously it timed only the creation of the
  coroutine — and that a call which raises is still recorded.
- `profile`'s keyword-only signature, the `ValueError` for `report_every < 1`,
  and the generator limitation.

## Gaps that were already there

- `format_elapsed_time`'s `precision` was documented as a `float`.
- Typing modernised to match the code: `str | None`, `list[Lap]`,
  `dict[str, float]`.
- `lap()` had a single sentence. It now covers nesting, being closed when the
  block raises, and taking over the lap started at construction — the three
  things most likely to surprise someone.
- `Statistics` raises on an empty set of values for everything except `total`.
  That was written down nowhere.
- `running` reflects any running lap.
- Getting Started never stated the required Python version.
- The `[module:function:line]` prefix on `print_report` was never explained.

## New "Measuring laps" guide

Laps and statistics are what the comparison table sells as the differentiators
against the other timer libraries, and they only appeared in scattered API
examples with no guide of their own. The new page covers timing each iteration,
leaving setup out, statistics across laps, nesting, exceptions, and manual
start/stop. All outputs verified.

## Two rendering bugs fixed

- **Twitter cards**: `twitter:title` and `twitter:image` were passing the
  strings `"ogTitle"` and `"ogImage"` instead of the variables, so any shared
  link produced a card titled "ogTitle" with a broken image.
- **Code focus marker**: the `lap` example used `// [!code focus]` inside a
  Python block. The comment syntax has to match the language, so it was never
  stripped and the marker was visible on the published page.

## Light mode was failing contrast badly

The palette was one set of yellows for both modes. Against the light
background, `#ffd859` is **1.38:1** where WCAG AA asks 4.5:1 for body text — so
every link on the site was nearly invisible in light mode. `#ffb727` is 1.74:1
and `#d8a72a` is 2.22:1; all three failed. On dark, the same yellow is 12.44:1.

Light mode now uses darkened ambers for text (`#8a6100` at 5.54:1, `#6f4e00` at
7.59:1 for hover) and keeps the vivid yellow for solid fills only. Brand buttons
are yellow in both modes and VitePress defaults their label to white — that same
1.38:1 — so they now use a dark label at 12.44:1. The hero name gradient is
dark-mode only, since a yellow gradient over a white page tops out at 1.74:1,
below even the 3:1 large text is allowed.

Ratios were computed, not eyeballed, and both modes were rendered in a browser
and compared side by side. That render caught a real mistake: `:root` and
`.dark` have equal specificity, so a later `:root` block was overriding the dark
values and the hero title came out dark-amber-on-dark. Every dark override now
lives in a single `.dark` block at the end of the file.

## VitePress 2.0.0-alpha.19

The site was on `1.0.0-rc.21`, a release candidate from 2023. Build verified
locally: VitePress 2.0.0-alpha.19 on Vite 8.2.0, 13 pages rendered, 12 sitemap
entries, no warnings. VitePress fails the build on broken internal links, so the
new cross-links are checked.

This is an alpha and `1.6.4` is the current stable — a deliberate choice, not an
oversight. The custom theme is a two-line default-theme re-export plus a CSS
variables file and the config uses no custom Vite plugins, so the Vite 6
breaking change from alpha.1 does not apply.

## Note on reviewing this

`.vercel.sh` cancels any build where `VERCEL_ENV` is not `production`, so this
pull request will **not** produce a preview deployment — that is by design.
Verification was local: `yarn build` plus browser renders of both colour modes.
Run `yarn install && yarn dev` to see it yourself before merging.